### PR TITLE
Modify print_disk_info. Now there is no output if the path is no mountpoint.

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -386,6 +386,7 @@ int main(int argc, char *argv[]) {
 
         cfg_opt_t disk_opts[] = {
                 CFG_STR("format", "%free", CFGF_NONE),
+                CFG_STR("format_not_mounted", NULL, CFGF_NONE),
                 CFG_STR("prefix_type", "binary", CFGF_NONE),
                 CFG_STR("threshold_type", "percentage_avail", CFGF_NONE),
                 CFG_FLOAT("low_threshold", 0, CFGF_NONE),
@@ -621,7 +622,7 @@ int main(int argc, char *argv[]) {
 
                         CASE_SEC_TITLE("disk") {
                                 SEC_OPEN_MAP("disk_info");
-                                print_disk_info(json_gen, buffer, title, cfg_getstr(sec, "format"), cfg_getstr(sec, "prefix_type"), cfg_getstr(sec, "threshold_type"), cfg_getfloat(sec, "low_threshold"));
+                                print_disk_info(json_gen, buffer, title, cfg_getstr(sec, "format"), cfg_getstr(sec, "format_not_mounted"), cfg_getstr(sec, "prefix_type"), cfg_getstr(sec, "threshold_type"), cfg_getfloat(sec, "low_threshold"));
                                 SEC_CLOSE_MAP;
                         }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -178,7 +178,7 @@ typedef enum {
 const char *first_eth_interface(const net_type_t type);
 
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
-void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *prefix_type, const char *threshold_type, const double low_threshold);
+void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);
 void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
 void print_time(yajl_gen json_gen, char *buffer, const char *format, const char *tz, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -237,6 +237,11 @@ space is below 2 GiB, it will be colored bad. If not specified, threshold_type
 is assumed to be "percentage_avail" and low_threshold to be set to 0, which
 implies no coloring at all.
 
+You can define a different format with the option "format_not_mounted"
+which is used if the path is not a mount point. So you can just empty
+the output for the given path with adding »format_not_mounted=""«
+to the config section.
+
 *Example order*: +disk /mnt/usbstick+
 
 *Example format*: +%free (%avail)/ %total+

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -131,7 +131,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
                 struct mntent *m;
                 bool found = false;
 
-                while (NULL != (m = getmntent(mntentfile))) {
+                while ((m = getmntent(mntentfile)) != NULL) {
                         if (strcmp(m->mnt_dir, path) == 0) {
                                 found = true;
                                 break;

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -125,7 +125,6 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
 
         if (statvfs(path, &buf) == -1)
                 return;
-#endif
 
         FILE *mntentfile = setmntent("/etc/mtab", "r");
         struct mntent *m;
@@ -144,6 +143,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
                 OUTPUT_FULL_TEXT(buffer);
                 return;
         }
+#endif
 
         if (low_threshold > 0 && below_threshold(buf, prefix_type, threshold_type, low_threshold)) {
                 START_COLOR("color_bad");

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -108,7 +108,7 @@ static bool below_threshold(struct statvfs buf, const char *prefix_type, const c
  * human readable manner.
  *
  */
-void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *prefix_type, const char *threshold_type, const double low_threshold) {
+void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold) {
         const char *walk;
         char *outwalk = buffer;
         bool colorful_output = false;
@@ -126,22 +126,22 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
         if (statvfs(path, &buf) == -1)
                 return;
 
-        FILE *mntentfile = setmntent("/etc/mtab", "r");
-        struct mntent *m;
-        bool found = false;
+        if (format_not_mounted != NULL) {
+                FILE *mntentfile = setmntent("/etc/mtab", "r");
+                struct mntent *m;
+                bool found = false;
 
-        while (NULL != (m = getmntent(mntentfile))) {
-                if (strcmp(m->mnt_dir, path) == 0) {
-                        found = true;
-                        break;
+                while (NULL != (m = getmntent(mntentfile))) {
+                        if (strcmp(m->mnt_dir, path) == 0) {
+                                found = true;
+                                break;
+                        }
                 }
-        }
-        endmntent(mntentfile);
+                endmntent(mntentfile);
 
-        if (!found) {
-                *buffer = '\0';
-                OUTPUT_FULL_TEXT(buffer);
-                return;
+                if (!found) {
+                        format = format_not_mounted;
+                }
         }
 #endif
 

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -131,7 +131,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
         struct mntent *m;
         bool found = false;
 
-        while ((m = getmntent(mntentfile))) {
+        while (NULL != (m = getmntent(mntentfile))) {
                 if (strcmp(m->mnt_dir, path) == 0) {
                         found = true;
                         break;
@@ -139,8 +139,8 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
         }
         endmntent(mntentfile);
 
-        if(!found) {
-                *outwalk = '\0';
+        if (!found) {
+                *buffer = '\0';
                 OUTPUT_FULL_TEXT(buffer);
                 return;
         }


### PR DESCRIPTION
If there is the tested path is no mountpoint, I do not want any output in the statusbar.
Adding options to configure the format_not_mounted or something else, I do not have the knowlegde at the moment.