### PR TITLE
Adding format_down option to path_exists and run_watch

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -287,6 +287,7 @@ int main(int argc, char *argv[]) {
     cfg_opt_t run_watch_opts[] = {
         CFG_STR("pidfile", NULL, CFGF_NONE),
         CFG_STR("format", "%title: %status", CFGF_NONE),
+        CFG_STR("format_down", NULL, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -295,6 +296,7 @@ int main(int argc, char *argv[]) {
     cfg_opt_t path_exists_opts[] = {
         CFG_STR("path", NULL, CFGF_NONE),
         CFG_STR("format", "%title: %status", CFGF_NONE),
+        CFG_STR("format_down", NULL, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -603,13 +605,13 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("run_watch") {
                 SEC_OPEN_MAP("run_watch");
-                print_run_watch(json_gen, buffer, title, cfg_getstr(sec, "pidfile"), cfg_getstr(sec, "format"));
+                print_run_watch(json_gen, buffer, title, cfg_getstr(sec, "pidfile"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"));
                 SEC_CLOSE_MAP;
             }
 
             CASE_SEC_TITLE("path_exists") {
                 SEC_OPEN_MAP("path_exists");
-                print_path_exists(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"));
+                print_path_exists(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -187,8 +187,8 @@ void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
 const char *get_ip_addr(const char *interface);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
-void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format);
-void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format);
+void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
+void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);
 void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -239,7 +239,7 @@ implies no coloring at all.
 
 You can define a different format with the option "format_not_mounted"
 which is used if the path is not a mount point. So you can just empty
-the output for the given path with adding »format_not_mounted=""«
+the output for the given path with adding +format_not_mounted=""+
 to the config section.
 
 *Example order*: +disk /mnt/usbstick+
@@ -259,6 +259,8 @@ to the config section.
 Expands the given path to a pidfile and checks if the process ID found inside
 is valid (that is, if the process is running). You can use this to check if
 a specific application, such as a VPN client or your DHCP client is running.
+There also is an option "format_down". You can hide the output with
++format_down=""+.
 
 *Example order*: +run_watch DHCP+
 
@@ -268,6 +270,8 @@ a specific application, such as a VPN client or your DHCP client is running.
 
 Checks if the given path exists in the filesystem. You can use this to check if
 something is active, like for example a VPN tunnel managed by NetworkManager.
+There also is an option "format_down". You can hide the output with
++format_down=""+.
 
 *Example order*: +path_exists VPN+
 

--- a/src/print_path_exists.c
+++ b/src/print_path_exists.c
@@ -6,17 +6,23 @@
 #include <sys/stat.h>
 #include "i3status.h"
 
-void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format) {
+void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down) {
     const char *walk;
     char *outwalk = buffer;
     struct stat st;
     const bool exists = (stat(path, &st) == 0);
 
+    if (exists || format_down == NULL) {
+        walk = format;
+    } else {
+        walk = format_down;
+    }
+
     INSTANCE(path);
 
     START_COLOR((exists ? "color_good" : "color_bad"));
 
-    for (walk = format; *walk != '\0'; walk++) {
+    for (; *walk != '\0'; walk++) {
         if (*walk != '%') {
             *(outwalk++) = *walk;
             continue;

--- a/src/print_run_watch.c
+++ b/src/print_run_watch.c
@@ -5,16 +5,22 @@
 #include <yajl/yajl_version.h>
 #include "i3status.h"
 
-void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format) {
+void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down) {
     bool running = process_runs(pidfile);
     const char *walk;
     char *outwalk = buffer;
+
+    if (running || format_down == NULL) {
+        walk = format;
+    } else {
+        walk = format_down;
+    }
 
     INSTANCE(pidfile);
 
     START_COLOR((running ? "color_good" : "color_bad"));
 
-    for (walk = format; *walk != '\0'; walk++) {
+    for (; *walk != '\0'; walk++) {
         if (*walk != '%') {
             *(outwalk++) = *walk;
             continue;


### PR DESCRIPTION
According to #1 the option format_down (to hide the output) is missing on path_exists. This also add the option to run_watch.
Do not change behavior without editing config, so no user will claim the new optional behaviour!