### PR TITLE
sys/dkstat.h has been removed from OpenBSD and it's functionality actual...

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -10,7 +10,11 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#if defined(__OpenBSD__)
+#include <sys/sched.h>
+#else
 #include <sys/dkstat.h>
+#endif
 #endif
 
 #if defined(__DragonFly__)


### PR DESCRIPTION
...ly lived/lives in sys/sched.h