### PR TITLE
add readline from file status option

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -298,6 +298,14 @@ int main(int argc, char *argv[]) {
         CFG_STR("format", "%title: %status", CFGF_NONE),
         CFG_STR("format_down", NULL, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()};
+
+    cfg_opt_t readline_opts[] = {
+        CFG_STR("path", NULL, CFGF_NONE),
+        CFG_STR("format", "%title: %status", CFGF_NONE),
+        CFG_STR("format_down", NULL, CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
@@ -412,6 +420,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("general", general_opts, CFGF_NONE),
         CFG_SEC("run_watch", run_watch_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("path_exists", path_exists_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("readline", readline_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("wireless", wireless_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ethernet", ethernet_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("battery", battery_opts, CFGF_TITLE | CFGF_MULTI),
@@ -612,6 +621,12 @@ int main(int argc, char *argv[]) {
             CASE_SEC_TITLE("path_exists") {
                 SEC_OPEN_MAP("path_exists");
                 print_path_exists(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("readline") {
+                SEC_OPEN_MAP("readline");
+                print_readline(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"));
                 SEC_CLOSE_MAP;
             }
 

--- a/i3status.c
+++ b/i3status.c
@@ -298,6 +298,7 @@ int main(int argc, char *argv[]) {
         CFG_STR("format", "%title: %status", CFGF_NONE),
         CFG_STR("format_down", NULL, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -189,6 +189,7 @@ const char *get_ip_addr(const char *interface);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
+void print_readline(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);
 void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);

--- a/src/print_readline.c
+++ b/src/print_readline.c
@@ -1,0 +1,71 @@
+// vim:ts=4:sw=4:expandtab
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+#include <sys/stat.h>
+#include "i3status.h"
+
+void print_readline(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down) {
+    const char *walk;
+    char *outwalk = buffer, line[256], *ptr;
+
+    memset(line, 0, sizeof(line));
+
+    int fd = open(path, O_RDONLY);
+    if (fd >= 0 || format_down == NULL) {
+        walk = format;
+        read(fd, line, sizeof(line)-1);
+        close(fd);
+    } else {
+        walk = format_down;
+    }
+
+    // Sanitize the line.
+    for (const char *in = ptr = line; *in != 0; in++) {
+        // End at newlines.
+        if(*in == '\r' || *in == '\n') {
+            *ptr = 0;
+            break;
+        }
+
+        // Replace non-printable characters by whitespaces, but do not
+        // emit multiple consecutive whitespaces.
+        if(isprint(*in) == 0) {
+            if(ptr != line && ptr[-1] != ' ') {
+                *ptr++ = ' ';
+            }
+        }
+        else {
+            *ptr++ = *in;
+        }
+    }
+
+    // Strip a trailing whitespace.
+    if(*ptr == ' ') {
+        ptr--;
+    }
+
+    *ptr = 0;
+
+    INSTANCE(path);
+
+    for (; *walk != '\0'; walk++) {
+        if (*walk != '%') {
+            *(outwalk++) = *walk;
+            continue;
+        }
+
+        if (BEGINS_WITH(walk + 1, "title")) {
+            outwalk += sprintf(outwalk, "%s", title);
+            walk += strlen("title");
+        } else if (BEGINS_WITH(walk + 1, "status")) {
+            outwalk += sprintf(outwalk, "%s", line);
+            walk += strlen("status");
+        }
+    }
+
+    OUTPUT_FULL_TEXT(buffer);
+}

--- a/src/print_readline.c
+++ b/src/print_readline.c
@@ -52,6 +52,8 @@ void print_readline(yajl_gen json_gen, char *buffer, const char *title, const ch
 
     INSTANCE(path);
 
+    START_COLOR((ptr != line ? "color_good" : "color_bad"));
+
     for (; *walk != '\0'; walk++) {
         if (*walk != '%') {
             *(outwalk++) = *walk;
@@ -62,10 +64,11 @@ void print_readline(yajl_gen json_gen, char *buffer, const char *title, const ch
             outwalk += sprintf(outwalk, "%s", title);
             walk += strlen("title");
         } else if (BEGINS_WITH(walk + 1, "status")) {
-            outwalk += sprintf(outwalk, "%s", line);
+            outwalk += sprintf(outwalk, "%s", ptr != line ? line : "no");
             walk += strlen("status");
         }
     }
 
+    END_COLOR;
     OUTPUT_FULL_TEXT(buffer);
 }

--- a/src/print_readline.c
+++ b/src/print_readline.c
@@ -17,7 +17,7 @@ void print_readline(yajl_gen json_gen, char *buffer, const char *title, const ch
     int fd = open(path, O_RDONLY);
     if (fd >= 0 || format_down == NULL) {
         walk = format;
-        read(fd, line, sizeof(line)-1);
+        read(fd, line, sizeof(line) - 1);
         close(fd);
     } else {
         walk = format_down;
@@ -26,25 +26,24 @@ void print_readline(yajl_gen json_gen, char *buffer, const char *title, const ch
     // Sanitize the line.
     for (const char *in = ptr = line; *in != 0; in++) {
         // End at newlines.
-        if(*in == '\r' || *in == '\n') {
+        if (*in == '\r' || *in == '\n') {
             *ptr = 0;
             break;
         }
 
         // Replace non-printable characters by whitespaces, but do not
         // emit multiple consecutive whitespaces.
-        if(isprint(*in) == 0) {
-            if(ptr != line && ptr[-1] != ' ') {
+        if (isprint(*in) == 0) {
+            if (ptr != line && ptr[-1] != ' ') {
                 *ptr++ = ' ';
             }
-        }
-        else {
+        } else {
             *ptr++ = *in;
         }
     }
 
     // Strip a trailing whitespace.
-    if(*ptr == ' ') {
+    if (*ptr == ' ') {
         ptr--;
     }
 

--- a/src/print_readline.c
+++ b/src/print_readline.c
@@ -15,10 +15,13 @@ void print_readline(yajl_gen json_gen, char *buffer, const char *title, const ch
     memset(line, 0, sizeof(line));
 
     int fd = open(path, O_RDONLY);
-    if (fd >= 0 || format_down == NULL) {
-        walk = format;
+    if (fd >= 0) {
         read(fd, line, sizeof(line) - 1);
         close(fd);
+    }
+
+    if (format_down == NULL) {
+        walk = format;
     } else {
         walk = format_down;
     }


### PR DESCRIPTION
Allows one to do the following in the ``~/.i3status.conf``:

```
order += "readline HOSTS"

...

readline HOSTS {
    path = "/etc/hosts"
}
```

It handles invalid non-printable characters and doesn't emit multiple consecutive whitespaces. For me this is useful so I can write a cronjob which updates a textfile every now and then, and then I can see this updated value in the i3status bar.

Jurriaan