### PR TITLE
Added support for separator_block_width

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -282,6 +282,7 @@ int main(int argc, char *argv[]) {
         CFG_STR("output_format", "auto", CFGF_NONE),
         CFG_BOOL("colors", 1, CFGF_NONE),
         CFG_STR("separator", "default", CFGF_NONE),
+        CFG_INT("separator_block_width", 9, CFGF_NONE),
         CFG_STR("color_separator", "#333333", CFGF_NONE),
         CFG_INT("interval", 1, CFGF_NONE),
         CFG_COLOR_OPTS("#00FF00", "#FFFF00", "#FF0000"),

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -88,32 +88,37 @@ enum { O_DZEN2,
         }                                                                              \
     } while (0)
 
-#define SEC_CLOSE_MAP                                                                                    \
-    do {                                                                                                 \
-        if (output_format == O_I3BAR) {                                                                  \
-            char *_align = cfg_getstr(sec, "align");                                                     \
-            if (_align) {                                                                                \
-                yajl_gen_string(json_gen, (const unsigned char *) "align", strlen("align"));             \
-                yajl_gen_string(json_gen, (const unsigned char *)_align, strlen(_align));                \
-            }                                                                                            \
-            struct min_width *_width = cfg_getptr(sec, "min_width");                                     \
-            if (_width) {                                                                                \
-                /* if the value can be parsed as a number, we use the numerical value */                 \
-                if (_width->num > 0) {                                                                   \
-                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width")); \
-                    yajl_gen_integer(json_gen, _width->num);                                             \
-                } else {                                                                                 \
-                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width")); \
-                    yajl_gen_string(json_gen, (const unsigned char *)_width->str, strlen(_width->str));  \
-                }                                                                                        \
-            }                                                                                            \
-            const char *_sep = cfg_getstr(cfg_general, "separator");                                     \
-            if (strlen(_sep) == 0) {                                                                     \
-                yajl_gen_string(json_gen, (const unsigned char *) "separator", strlen("separator"));     \
-                yajl_gen_bool(json_gen, false);                                                          \
-            }                                                                                            \
-            yajl_gen_map_close(json_gen);                                                                \
-        }                                                                                                \
+#define SEC_CLOSE_MAP                                                                                                        \
+    do {                                                                                                                     \
+        if (output_format == O_I3BAR) {                                                                                      \
+            char *_align = cfg_getstr(sec, "align");                                                                         \
+            if (_align) {                                                                                                    \
+                yajl_gen_string(json_gen, (const unsigned char *) "align", strlen("align"));                                 \
+                yajl_gen_string(json_gen, (const unsigned char *)_align, strlen(_align));                                    \
+            }                                                                                                                \
+            struct min_width *_width = cfg_getptr(sec, "min_width");                                                         \
+            if (_width) {                                                                                                    \
+                /* if the value can be parsed as a number, we use the numerical value */                                     \
+                if (_width->num > 0) {                                                                                       \
+                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width"));                     \
+                    yajl_gen_integer(json_gen, _width->num);                                                                 \
+                } else {                                                                                                     \
+                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width"));                     \
+                    yajl_gen_string(json_gen, (const unsigned char *)_width->str, strlen(_width->str));                      \
+                }                                                                                                            \
+            }                                                                                                                \
+            const char *_sep = cfg_getstr(cfg_general, "separator");                                                         \
+            if (strlen(_sep) == 0) {                                                                                         \
+                yajl_gen_string(json_gen, (const unsigned char *) "separator", strlen("separator"));                         \
+                yajl_gen_bool(json_gen, false);                                                                              \
+            }                                                                                                                \
+            const int _sep_block_width = cfg_getint(cfg_general, "separator_block_width");                                   \
+            if (_sep_block_width != 9) {                                                                                     \
+                yajl_gen_string(json_gen, (const unsigned char *) "separator_block_width", strlen("separator_block_width")); \
+                yajl_gen_integer(json_gen, _sep_block_width);                                                                \
+            }                                                                                                                \
+            yajl_gen_map_close(json_gen);                                                                                    \
+        }                                                                                                                    \
     } while (0)
 
 #define START_COLOR(colorstr)                                                                \


### PR DESCRIPTION
The general section of the config can now accept a 'separator_block_width' which will be used if the output_format is i3bar.
The value will only be included in the JSON output if it differs from 9, which is the default in i3.

fixes #20