### PR TITLE
Add support for differing PREFIX and MANPREFIX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 ifndef PREFIX
   PREFIX=/usr
 endif
+ifndef MANPREFIX
+  MANPREFIX=$(PREFIX)
+endif
 ifndef SYSCONFDIR
   ifeq ($(PREFIX),/usr)
     SYSCONFDIR=/etc
@@ -95,12 +98,12 @@ manpage:
 install:
 	install -m 755 -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 -d $(DESTDIR)$(SYSCONFDIR)
-	install -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 755 -d $(DESTDIR)$(MANPREFIX)/share/man/man1
 	install -m 755 i3status $(DESTDIR)$(PREFIX)/bin/i3status
 	# Allow network configuration for getting the link speed
 	(which setcap && setcap cap_net_admin=ep $(DESTDIR)$(PREFIX)/bin/i3status) || true
 	install -m 644 i3status.conf $(DESTDIR)$(SYSCONFDIR)/i3status.conf
-	install -m 644 man/i3status.1 $(DESTDIR)$(PREFIX)/share/man/man1
+	install -m 644 man/i3status.1 $(DESTDIR)$(MANPREFIX)/share/man/man1
 
 release:
 	[ -f i3status-${VERSION} ] || rm -rf i3status-${VERSION}


### PR DESCRIPTION
Sometimes we do not want man pages to go to $(PREFIX)/man, as in the
case of cross-compiling on distributions such as Exherbo.