### PR TITLE
if the volume device is "alsa", force using ALSA PulseAudio emulation

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -447,6 +447,8 @@ default is used. If the device string is missing or is set to "default",
 PulseAudio will be tried if detected and will fallback to ALSA (Linux)
 or OSS (FreeBSD/OpenBSD).
 
+To force PulseAudio using ALSA emulation, use "alsa" as the device name.
+
 *Example order*: +volume master+
 
 *Example format*: +♪: %volume+

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -99,7 +99,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
     }
 
     /* Attach this mixer handle to the given device */
-    if ((err = snd_mixer_attach(m, device)) < 0) {
+    if (!strcasecmp(device, "alsa") ? (err = snd_mixer_attach(m, "pulse")) < 0 : (err = snd_mixer_attach(m, device)) < 0) {
         fprintf(stderr, "i3status: ALSA: Cannot attach mixer to device: %s\n", snd_strerror(err));
         snd_mixer_close(m);
         goto out;


### PR DESCRIPTION
The ability to force using the "pulse" ALSA device (using PulseAudio through ALSA emulation) was missing. This patch makes that possible by specifying the device "alsa".