### PR TITLE
Print current keyboard layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CFLAGS+=-Iinclude
 LIBS+=-lconfuse
 LIBS+=-lyajl
 LIBS+=-lpulse
+LIBS+=-lX11 -lxkbfile
 
 VERSION:=$(shell git describe --tags --abbrev=0)
 GIT_VERSION:="$(shell git describe --tags --always) ($(shell git log --pretty=format:%cd --date=short -n1))"

--- a/i3status.c
+++ b/i3status.c
@@ -410,6 +410,14 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t keyboard_layout_opts[] = {
+        CFG_STR("format", "L: %s", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()
+    };
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
@@ -421,6 +429,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("cpu_temperature", temp_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("disk", disk_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("volume", volume_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("keyboard_layout", keyboard_layout_opts, CFGF_NONE),
         CFG_SEC("ipv6", ipv6_opts, CFGF_NONE),
         CFG_SEC("time", time_opts, CFGF_NONE),
         CFG_SEC("tztime", tztime_opts, CFGF_TITLE | CFGF_MULTI),
@@ -656,6 +665,12 @@ int main(int argc, char *argv[]) {
                              cfg_getstr(sec, "device"),
                              cfg_getstr(sec, "mixer"),
                              cfg_getint(sec, "mixer_idx"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC("keyboard_layout") {
+                SEC_OPEN_MAP("keyboard_layout");
+                print_keyboard_layout(json_gen, buffer, cfg_getstr(sec, "format"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -201,6 +201,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
+void print_keyboard_layout(yajl_gen json_gen, char *buffer, const char *fmt);
 bool process_runs(const char *path);
 int volume_pulseaudio(uint32_t sink_idx);
 bool pulse_initialize(void);

--- a/src/print_keyboard_layout.c
+++ b/src/print_keyboard_layout.c
@@ -1,0 +1,27 @@
+// vim:ts=4:sw=4:expandtab
+
+#include "i3status.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+#include <X11/Xlib.h>
+#include <X11/XKBlib.h>
+#include <X11/extensions/XKBrules.h>
+
+const char *getKeyboardLayout() {
+    Display *dpy = XkbOpenDisplay(NULL, NULL, NULL, NULL, NULL, NULL);
+    XkbRF_VarDefsRec vd;
+    char *tmp = NULL;
+    XkbRF_GetNamesProp(dpy, &tmp, &vd);
+    XCloseDisplay(dpy);
+    return vd.layout;
+}
+
+void print_keyboard_layout(yajl_gen json_gen, char *buffer, const char *format) {
+    char *outwalk = buffer;
+    outwalk += sprintf(outwalk, format, getKeyboardLayout());
+    *outwalk = '\0';
+    OUTPUT_FULL_TEXT(buffer);
+}


### PR DESCRIPTION
I frequently switch keyboard layouts so I find it useful to know which one is current from the status bar.  With this patch I just add `order += "keyboard_layout"` to get, for instance, `L: us_intl` added to the status bar.