### PR TITLE
Add missing dependency information

### DIFF
--- a/README
+++ b/README
@@ -21,9 +21,11 @@ i3status has the following dependencies:
  • libcap2-bin (for getting network status without root permissions)
  • asciidoc (only for the documentation)
  • libpulse-dev (for getting the current volume using PulseAudio)
+ • libxml2-utils (for xmllint)
+ • xsltproc
 
 On debian-based systems, the following line will install all requirements:
-apt-get install libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libcap2-bin libpulse-dev
+apt-get install libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libcap2-bin libpulse-dev libxml2-utils xsltproc
 
  ┌────────────────────────────┐
  │ Upstream                   │


### PR DESCRIPTION
The following additional packages were needed to build:
libxml2-utils, xsltproc