### PR TITLE
SIGUSR1 fix regains capability to force status update. Maybe just tem…

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -74,14 +74,21 @@ pthread_mutex_t i3status_sleep_mutex = PTHREAD_MUTEX_INITIALIZER;
  */
 void fatalsig(int signum) {
     exit_upon_signal = true;
+    // Broadcast ensures swift reaction times
+    // pthread_mutex_lock(&i3status_sleep_mutex);
+    pthread_cond_broadcast(&i3status_sleep_cond);
+    // pthread_mutex_unlock(&i3status_sleep_mutex);
 }
 
 /*
- * Do nothing upon SIGUSR1. Running this signal handler will nevertheless
- * interrupt nanosleep() so that i3status immediately generates new output.
+ * Here, we wake up the main thread sleeping. 
+ * This restores the lost capability to react to the SIGUSR1 signal.
  *
  */
 void sigusr1(int signum) {
+    // pthread_mutex_lock(&i3status_sleep_mutex);
+    pthread_cond_broadcast(&i3status_sleep_cond);
+    // pthread_mutex_unlock(&i3status_sleep_mutex);
 }
 
 /*


### PR DESCRIPTION
Attempt to fix regression in the reaction to signals. SIGUSR1 can be used to force the update again. Re-enables prompt reaction to SIGTERM signal. I think this capability should be preservet, not everything can be rewritten into async model like print_volume.

Re-enables this kind of commands:
`bindsym XF86AudioRaiseVolume exec --no-startup-id ~/.i3/raise_vol.sh && killall -SIGUSR1 i3status`