### PR TITLE
Mac OS X compatibility changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ ifeq ($(OS),OpenBSD)
 LIBS+=-lossaudio
 endif
 
-ifeq ($(OS), NetBSD)
-LIBS+= -lprop
+ifeq ($(OS),NetBSD)
+LIBS+=-lprop
 endif
 
 # This probably applies for any pkgsrc based system

--- a/i3status.c
+++ b/i3status.c
@@ -692,7 +692,12 @@ int main(int argc, char *argv[]) {
          * We also align to 60 seconds modulo interval such
          * that we start with :00 on every new minute. */
         struct timespec ts;
+#if defined(__APPLE__)
+        gettimeofday(&tv, NULL);
+        ts.tv_sec = tv.tv_sec;
+#else
         clock_gettime(CLOCK_REALTIME, &ts);
+#endif
         ts.tv_sec += interval - (ts.tv_sec % interval);
         ts.tv_nsec = 0;
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,8 +1,9 @@
 all: i3status.1
 
 A2X?=a2x
+A2X_FLAGS=
 
 i3status.1: asciidoc.conf i3status.man
-	${A2X} -f manpage --asciidoc-opts="-f asciidoc.conf" i3status.man
+	${A2X} -f manpage --asciidoc-opts="-f asciidoc.conf" ${A2X_FLAGS} i3status.man
 clean:
 	rm -f i3status.xml i3status.1 i3status.html

--- a/src/print_cpu_temperature.c
+++ b/src/print_cpu_temperature.c
@@ -261,8 +261,8 @@ void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const
     OUTPUT_FULL_TEXT(buffer);
     return;
 error:
-#endif
     free(thermal_zone);
+#endif
 
     OUTPUT_FULL_TEXT("can't read temp");
     (void)fputs("i3status: Cannot read temperature. Verify that you have a thermal zone in /sys/class/thermal or disable the cpu_temperature module in your i3status config.\n", stderr);

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/types.h>
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (__OpenBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #else
@@ -59,7 +59,7 @@ static int print_bytes_human(char *outwalk, uint64_t bytes, const char *prefix_t
  * Determines whether remaining bytes are below given threshold.
  *
  */
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
 static bool below_threshold(struct statfs buf, const char *prefix_type, const char *threshold_type, const double low_threshold) {
 #else
 static bool below_threshold(struct statvfs buf, const char *prefix_type, const char *threshold_type, const double low_threshold) {
@@ -116,7 +116,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
 
     INSTANCE(path);
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
     struct statfs buf;
 
     if (statfs(path, &buf) == -1)


### PR DESCRIPTION
Some minor changes to make i3status compile under OS X.

:warning: I'm uncertain whether the additional call to `gettimeofday` in https://github.com/i3/i3status/commit/2113737107c537e9cbc1a40d2d8d5fac5152e03e is really necessary or whether the call to `gettimeofday`in line 563 is enough.
What's your opinion?