### PR TITLE
Add missing fixes from OpenBSD ports tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,11 @@ CFLAGS += -idirafter yajl-fallback
 OBJS:=$(wildcard src/*.c *.c)
 OBJS:=$(OBJS:.c=.o)
 
+ifeq ($(OS),OpenBSD)
+OBJS:=$(filter-out src/pulse.o, $(OBJS))
+LIBS:=$(filter-out -lpulse, $(LIBS)) -lpthread
+endif
+
 src/%.o: src/%.c include/i3status.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 	@echo " CC $<"

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,6 @@ CFLAGS+=-I/usr/local/include/
 LDFLAGS+=-L/usr/local/lib/
 endif
 
-ifeq ($(OS),OpenBSD)
-LIBS+=-lossaudio
-endif
-
 ifeq ($(OS),NetBSD)
 LIBS+=-lprop
 endif

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -223,14 +223,10 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
 
     devinfo2.index = 0;
     while (ioctl(mixfd, AUDIO_MIXER_DEVINFO, &devinfo2) >= 0) {
-        if ((devinfo2.type == AUDIO_MIXER_VALUE)
-        &&  (devinfo2.mixer_class == oclass_idx)
-        &&  (strncmp(devinfo2.label.name, AudioNmaster, MAX_AUDIO_DEV_LEN) == 0))
+        if ((devinfo2.type == AUDIO_MIXER_VALUE) && (devinfo2.mixer_class == oclass_idx) && (strncmp(devinfo2.label.name, AudioNmaster, MAX_AUDIO_DEV_LEN) == 0))
             master_idx = devinfo2.index;
 
-        if ((devinfo2.type == AUDIO_MIXER_ENUM)
-        &&  (devinfo2.mixer_class == oclass_idx)
-        &&  (strncmp(devinfo2.label.name, AudioNmute, MAX_AUDIO_DEV_LEN) == 0))
+        if ((devinfo2.type == AUDIO_MIXER_ENUM) && (devinfo2.mixer_class == oclass_idx) && (strncmp(devinfo2.label.name, AudioNmute, MAX_AUDIO_DEV_LEN) == 0))
             master_mute_idx = devinfo2.index;
 
         devinfo2.index++;

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -21,7 +21,8 @@
 #ifdef __OpenBSD__
 #include <fcntl.h>
 #include <unistd.h>
-#include <soundcard.h>
+#include <sys/audioio.h>
+#include <sys/ioctl.h>
 #endif
 
 #include "i3status.h"
@@ -150,6 +151,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         snd_mixer_selem_id_free(sid);
         goto out;
     }
+#endif
 
     /* Get the volume range to convert the volume later */
     snd_mixer_selem_get_playback_volume_range(elem, &min, &max);
@@ -191,13 +193,81 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         mixerpath = defaultmixer;
 
     if ((mixfd = open(mixerpath, O_RDWR)) < 0) {
+#if defined(__OpenBSD__)
+        warn("AUDIO: Cannot open mixer");
+#else
         warn("OSS: Cannot open mixer");
+#endif
         goto out;
     }
 
     if (mixer_idx > 0)
         free(mixerpath);
 
+#if defined(__OpenBSD__)
+    int oclass_idx = -1, master_idx = -1, master_mute_idx = -1;
+    mixer_devinfo_t devinfo, devinfo2;
+    mixer_ctrl_t vinfo;
+
+    devinfo.index = 0;
+    while (ioctl(mixfd, AUDIO_MIXER_DEVINFO, &devinfo) >= 0) {
+        if (devinfo.type != AUDIO_MIXER_CLASS) {
+            devinfo.index++;
+            continue;
+        }
+        if (strncmp(devinfo.label.name, AudioCoutputs, MAX_AUDIO_DEV_LEN) == 0)
+            oclass_idx = devinfo.index;
+
+        devinfo.index++;
+    }
+
+    devinfo2.index = 0;
+    while (ioctl(mixfd, AUDIO_MIXER_DEVINFO, &devinfo2) >= 0) {
+        if ((devinfo2.type == AUDIO_MIXER_VALUE)
+        &&  (devinfo2.mixer_class == oclass_idx)
+        &&  (strncmp(devinfo2.label.name, AudioNmaster, MAX_AUDIO_DEV_LEN) == 0))
+            master_idx = devinfo2.index;
+
+        if ((devinfo2.type == AUDIO_MIXER_ENUM)
+        &&  (devinfo2.mixer_class == oclass_idx)
+        &&  (strncmp(devinfo2.label.name, AudioNmute, MAX_AUDIO_DEV_LEN) == 0))
+            master_mute_idx = devinfo2.index;
+
+        devinfo2.index++;
+    }
+
+    if (master_idx == -1)
+        goto out;
+
+    devinfo.index = master_idx;
+    if (ioctl(mixfd, AUDIO_MIXER_DEVINFO, &devinfo) == -1)
+        goto out;
+
+    vinfo.dev = master_idx;
+    vinfo.type = AUDIO_MIXER_VALUE;
+    if (ioctl(mixfd, AUDIO_MIXER_READ, &vinfo) == -1)
+        goto out;
+
+    if (AUDIO_MAX_GAIN != 100) {
+        float avgf = ((float)vinfo.un.value.level[AUDIO_MIXER_LEVEL_MONO] / AUDIO_MAX_GAIN) * 100;
+        vol = (int)avgf;
+        vol = (avgf - vol < 0.5 ? vol : (vol + 1));
+    } else {
+        vol = (int)vinfo.un.value.level[AUDIO_MIXER_LEVEL_MONO];
+    }
+
+    vinfo.dev = master_mute_idx;
+    vinfo.type = AUDIO_MIXER_ENUM;
+    if (ioctl(mixfd, AUDIO_MIXER_READ, &vinfo) == -1)
+        goto out;
+
+    if (master_mute_idx != -1 && vinfo.un.ord) {
+        START_COLOR("color_degraded");
+        fmt = fmt_muted;
+        pbval = 0;
+    }
+
+#else
     if (ioctl(mixfd, SOUND_MIXER_READ_DEVMASK, &devmask) == -1) {
         warn("OSS: Cannot read mixer information");
         goto out;

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -60,6 +60,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         free(instance);
     }
 
+#ifndef __OpenBSD__
     /* Try PulseAudio first */
 
     /* If the device name has the format "pulse[:N]" where N is the
@@ -101,6 +102,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
     }
 /* If some other device was specified or PulseAudio is not detected,
  * proceed to ALSA / OSS */
+#endif
 
 #ifdef LINUX
     int err;

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -151,7 +151,6 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         snd_mixer_selem_id_free(sid);
         goto out;
     }
-#endif
 
     /* Get the volume range to convert the volume later */
     snd_mixer_selem_get_playback_volume_range(elem, &min, &max);
@@ -194,7 +193,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
 
     if ((mixfd = open(mixerpath, O_RDWR)) < 0) {
 #if defined(__OpenBSD__)
-        warn("AUDIO: Cannot open mixer");
+        warn("audioio: Cannot open mixer");
 #else
         warn("OSS: Cannot open mixer");
 #endif
@@ -278,6 +277,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         pbval = 0;
     }
 
+#endif
     outwalk = apply_volume_format(fmt, outwalk, vol & 0x7f);
     close(mixfd);
 #endif


### PR DESCRIPTION
Apparently most patches from OpenBSD ports tree already made their way into i3. These remain.