### PR TITLE
Use "color_degraded" when interface has no IP

### DIFF
--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -126,7 +126,10 @@ void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, cons
         goto out;
     }
 
-    START_COLOR("color_good");
+    if (BEGINS_WITH(ip_address, "no IP"))
+        START_COLOR("color_degraded");
+    else
+        START_COLOR("color_good");
 
     for (walk = format_up; *walk != '\0'; walk++) {
         if (*walk != '%') {

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -342,7 +342,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY)
             START_COLOR((info.quality < info.quality_average ? "color_degraded" : "color_good"));
         else
-            START_COLOR("color_good");
+            START_COLOR((BEGINS_WITH(ip_address, "no IP") ? "color_degraded" : "color_good"));
     } else {
         walk = format_down;
         START_COLOR("color_bad");


### PR DESCRIPTION
On laptops one may want to have all interfaces up in order to let network
prioritization manage switching between wired and wireless connection.
In such cases lack of IP address is a useful hint about currently used
interface, and color-coding makes it stand out more.