### PR TITLE
Fix some issues with displaying Ethernet media status on recent FreeBSD kernels.

### DIFF
--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -21,8 +21,6 @@
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
 #include <net/if_media.h>
-#define IFM_TYPE_MATCH(dt, t) \
-    (IFM_TYPE((dt)) == 0 || IFM_TYPE((dt)) == IFM_TYPE((t)))
 
 #define PART_ETHSPEED "E: %s (%s)"
 #endif
@@ -53,21 +51,29 @@ static int print_eth_speed(char *outwalk, const char *interface) {
     struct ifmediareq ifm;
     (void)memset(&ifm, 0, sizeof(ifm));
     (void)strncpy(ifm.ifm_name, interface, sizeof(ifm.ifm_name));
-    if (ioctl(general_socket, SIOCGIFMEDIA, (caddr_t)&ifm) < 0) {
+    int ret;
+#ifdef SIOCGIFXMEDIA
+    ret = ioctl(general_socket, SIOCGIFXMEDIA, (caddr_t)&ifm);
+    if (ret < 0)
+#endif
+        ret = ioctl(general_socket, SIOCGIFMEDIA, (caddr_t)&ifm);
+    if (ret < 0)
         return sprintf(outwalk, "?");
-    }
 
     /* Get the description of the media type, partially taken from
      * FreeBSD's ifconfig */
     const struct ifmedia_description *desc;
-    struct ifmedia_description ifm_subtype_descriptions[] =
+    static struct ifmedia_description ifm_subtype_descriptions[] =
         IFM_SUBTYPE_ETHERNET_DESCRIPTIONS;
 
+    if (IFM_TYPE(ifm.ifm_active) != IFM_ETHER)
+        return sprintf(outwalk, "?");
+    if (ifm.ifm_status & IFM_AVALID && !(ifm.ifm_status & IFM_ACTIVE))
+        return sprintf(outwalk, "no carrier");
     for (desc = ifm_subtype_descriptions;
          desc->ifmt_string != NULL;
          desc++) {
-        if (IFM_TYPE_MATCH(desc->ifmt_word, ifm.ifm_active) &&
-            IFM_SUBTYPE(desc->ifmt_word) == IFM_SUBTYPE(ifm.ifm_active))
+        if (desc->ifmt_word == IFM_SUBTYPE(ifm.ifm_active))
             break;
     }
     ethspeed = (desc->ifmt_string != NULL ? desc->ifmt_string : "?");


### PR DESCRIPTION

- Don't apply IFM_SUBTYPE to the raw subtype in the description table.
  IFM_SUBTYPE() requires a fully populated word and was truncating values
  in the table when comparing resulting in false matches (notably
  "10GBase-KX4" for the no media case) after recent changes to add extended
  Ethernet media states in FreeBSD.
- Explicitly check for IFM_ETHER.
- Use SIOCGIFXMEDIA when present to obtain extended media states on newer
  kernels.
- Explicitly handle "no carrier".