### PR TITLE
Allow pulseaudio to be disabled at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CFLAGS+=-Iinclude
 LIBS+=-lconfuse
 LIBS+=-lyajl
 LIBS+=-lpulse
+LIBS+=-lpthread
 
 VERSION:=$(shell git describe --tags --abbrev=0)
 GIT_VERSION:="$(shell git describe --tags --always) ($(shell git log --pretty=format:%cd --date=short -n1))"
@@ -69,8 +70,13 @@ OBJS:=$(wildcard src/*.c *.c)
 OBJS:=$(OBJS:.c=.o)
 
 ifeq ($(OS),OpenBSD)
+DISABLE_PULSEAUDIO=yes
+endif
+
+ifdef DISABLE_PULSEAUDIO
+CFLAGS+=-DDISABLE_PULSEAUDIO
 OBJS:=$(filter-out src/pulse.o, $(OBJS))
-LIBS:=$(filter-out -lpulse, $(LIBS)) -lpthread
+LIBS:=$(filter-out -lpulse, $(LIBS))
 endif
 
 src/%.o: src/%.c include/i3status.h

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -60,7 +60,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         free(instance);
     }
 
-#ifndef __OpenBSD__
+#ifndef DISABLE_PULSEAUDIO
     /* Try PulseAudio first */
 
     /* If the device name has the format "pulse[:N]" where N is the


### PR DESCRIPTION
- If DISABLE_PULSEAUDIO is defined as a make variable, then disable
  use of pulseaudio.  This allows packages to optionally include
  pulseaudio support (for example in FreeBSD ports pulseaudio could
  become an OPTION on the next update).
- Explicitly link in -lpthread always.  The main loop uses pthread
  symbols directly, and on some systems libc only provides non-functional
  stubs.  On FreeBSD the pthread_cond_timedwait() stub returns instantly
  resulting in i3status never sleeping.
- Define DISABLE_PULSEAUDIO on OpenBSD by default to preserve existing
  behavior.