### PR TITLE
Add ratio_watch to support displaying display brightness.

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -420,6 +420,18 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t ratio_watch_opts[] = {
+        CFG_STR("format_down", "", CFGF_NONE),
+        CFG_STR("format_high", "☼: %percentage", CFGF_NONE),
+        CFG_STR("format_low", "☾: %percentage", CFGF_NONE),
+        CFG_STR("path_numerator", "/sys/class/backlight/*/brightness", CFGF_NONE),
+        CFG_STR("path_denominator", "/sys/class/backlight/*/max_brightness", CFGF_NONE),
+        CFG_FLOAT("low_threshold", 50, CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
@@ -437,6 +449,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("ddate", ddate_opts, CFGF_NONE),
         CFG_SEC("load", load_opts, CFGF_NONE),
         CFG_SEC("cpu_usage", usage_opts, CFGF_NONE),
+        CFG_SEC("ratio_watch", ratio_watch_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_END()};
 
     char *configfile = NULL;
@@ -637,6 +650,12 @@ int main(int argc, char *argv[]) {
             CASE_SEC_TITLE("disk") {
                 SEC_OPEN_MAP("disk_info");
                 print_disk_info(json_gen, buffer, title, cfg_getstr(sec, "format"), cfg_getstr(sec, "format_not_mounted"), cfg_getstr(sec, "prefix_type"), cfg_getstr(sec, "threshold_type"), cfg_getfloat(sec, "low_threshold"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("ratio_watch") {
+                SEC_OPEN_MAP("ratio_watch");
+                print_ratio_watch(json_gen, buffer, title, cfg_getstr(sec, "format_down"), cfg_getstr(sec, "format_high"), cfg_getstr(sec, "format_low"), cfg_getstr(sec, "path_numerator"), cfg_getstr(sec, "path_denominator"), cfg_getfloat(sec, "low_threshold"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -204,6 +204,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
+void print_ratio_watch(yajl_gen json_gen, char *buffer, const char *title, const char *format_down, const char *format_high, const char *format_low, const char *path_numerator, const char *path_denominator, const float low_threshold);
 bool process_runs(const char *path);
 int volume_pulseaudio(uint32_t sink_idx);
 bool pulse_initialize(void);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -59,6 +59,7 @@ order += "cpu_temperature 0"
 order += "load"
 order += "tztime local"
 order += "tztime berlin"
+order += "ratio_watch backlight"
 
 wireless wlan0 {
         format_up = "W: (%quality at %essid, %bitrate) %ip"
@@ -115,6 +116,15 @@ cpu_temperature 0 {
 
 disk "/" {
 	format = "%free"
+}
+
+ratio_watch backlight {
+  format_down = "N/A"
+  format_high = "☼: %percentage"
+  format_low = "☾: %percentage"
+  # globs are allowed in paths
+  path_numerator = "/sys/class/backlight/*/brightness"
+  path_denominator = "/sys/class/backlight/*/max_brightness"
 }
 -------------------------------------------------------------
 
@@ -472,6 +482,32 @@ volume master {
 	format = "♪: %volume"
 	format_muted = "♪: muted (%volume)"
 	device = "pulse:1"
+}
+-------------------------------------------------------------
+
+=== Ratio-watch
+
+Displays a ratio between two numbers found in files (e.g., backlight brigtness).
+Expands two given paths, the "path_numerator" and the "path_denominator", parses
+the content as numbers and computes the current ratio. The ratio is displayed as
+a percentage.
+
+*Example order*: +ratio_watch 0
+
+*Example format_down*: N/A
+
+*Example format_high*: ☼: %percentage
+
+*Example format_low*: ☾: %percentage
+
+*Example configuration*:
+-------------------------------------------------------------
+ratio_watch 0 {
+  format_down = ""
+  format_high = "☼: %percentage"
+  format_low = "☾: %percentage"
+  path_numerator = "/sys/class/backlight/*/brightness"
+  path_denominator = "/sys/class/backlight/*/max_brightness"
 }
 -------------------------------------------------------------
 

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -119,12 +119,12 @@ disk "/" {
 }
 
 ratio_watch backlight {
-  format_down = "N/A"
-  format_high = "☼: %percentage"
-  format_low = "☾: %percentage"
-  # globs are allowed in paths
-  path_numerator = "/sys/class/backlight/*/brightness"
-  path_denominator = "/sys/class/backlight/*/max_brightness"
+	format_down = "N/A"
+	format_high = "☼: %percentage"
+	format_low = "☾: %percentage"
+	# globs are allowed in paths
+	path_numerator = "/sys/class/backlight/*/brightness"
+	path_denominator = "/sys/class/backlight/*/max_brightness"
 }
 -------------------------------------------------------------
 
@@ -503,11 +503,11 @@ a percentage.
 *Example configuration*:
 -------------------------------------------------------------
 ratio_watch 0 {
-  format_down = ""
-  format_high = "☼: %percentage"
-  format_low = "☾: %percentage"
-  path_numerator = "/sys/class/backlight/*/brightness"
-  path_denominator = "/sys/class/backlight/*/max_brightness"
+	format_down = ""
+	format_high = "☼: %percentage"
+	format_low = "☾: %percentage"
+	path_numerator = "/sys/class/backlight/*/brightness"
+	path_denominator = "/sys/class/backlight/*/max_brightness"
 }
 -------------------------------------------------------------
 

--- a/src/print_ratio_watch.c
+++ b/src/print_ratio_watch.c
@@ -1,0 +1,78 @@
+// vim:ts=4:sw=4:expandtab
+#include <glob.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+
+#include "i3status.h"
+
+static bool file_read_number(const char *path, float *out) {
+    static char contentbuf[64];
+    if (!out)
+        die("out == NULL\n");
+    if (!slurp(path, contentbuf, sizeof(contentbuf)))
+        return false;
+    *out = strtof(contentbuf, NULL);
+    return true;
+}
+
+static bool glob_read_number(const char *path, float *out) {
+    static glob_t globbuf;
+    if (!out)
+        die("out == NULL\n");
+    if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) < 0)
+        die("glob() failed\n");
+    if (globbuf.gl_pathc == 0) {
+        globfree(&globbuf);
+        // No glob matches, the specified path does not contain a wildcard.
+        return file_read_number(path, out);
+    }
+    for (size_t i = 0; i < globbuf.gl_pathc; i++) {
+        if (file_read_number(globbuf.gl_pathv[i], out)) {
+            globfree(&globbuf);
+            return true;
+        }
+    }
+    globfree(&globbuf);
+    return false;
+}
+
+/**
+ * Computes the ratio of two numbers in files and displays them.
+ *
+ */
+void print_ratio_watch(yajl_gen json_gen, char *buffer, const char *title, const char *format_down, const char *format_high, const char *format_low, const char *path_numerator, const char *path_denominator, const float low_threshold) {
+    char *outwalk = buffer;
+    float numerator = 0.0;
+    float denominator = 0.0;
+
+    if (!glob_read_number(path_numerator, &numerator) ||
+        !glob_read_number(path_denominator, &denominator)) {
+        START_COLOR("color_bad");
+        outwalk += sprintf(outwalk, "%s", format_down);
+        END_COLOR;
+        OUTPUT_FULL_TEXT(buffer);
+        return;
+    }
+    float percentage = (numerator / denominator) * 100.0;
+    const char *walk = percentage >= low_threshold ? format_high : format_low;
+
+    for (; *walk != '\0'; walk++) {
+        if (*walk != '%') {
+            *(outwalk++) = *walk;
+            continue;
+        }
+
+        if (BEGINS_WITH(walk + 1, "percentage")) {
+            outwalk += sprintf(outwalk, "%.00f%s", percentage, pct_mark);
+            walk += strlen("percentage");
+        }
+    }
+
+    END_COLOR;
+    OUTPUT_FULL_TEXT(buffer);
+}

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -65,7 +65,9 @@
 typedef struct {
     int flags;
     char essid[IW_ESSID_MAX_SIZE + 1];
+#ifdef LINUX
     uint8_t bssid[ETH_ALEN];
+#endif
     int quality;
     int quality_max;
     int quality_average;
@@ -77,6 +79,7 @@ typedef struct {
     double frequency;
 } wireless_info_t;
 
+#ifdef LINUX
 // Like iw_print_bitrate, but without the dependency on libiw.
 static void print_bitrate(char *buffer, int buflen, int bitrate) {
     const int kilo = 1e3;
@@ -251,6 +254,7 @@ static int gwi_scan_cb(struct nl_msg *msg, void *data) {
 
     return NL_SKIP;
 }
+#endif
 
 static int get_wireless_info(const char *interface, wireless_info_t *info) {
     memset(info, 0, sizeof(wireless_info_t));


### PR DESCRIPTION
This is implemented by watching files in /sys/class/backlight. Tested on a Lenovo X1 with the intel_backlight module and linux 4.2.2.