### PR TITLE
format detection: recognise swaybar

### DIFF
--- a/src/auto_detect_format.c
+++ b/src/auto_detect_format.c
@@ -44,7 +44,7 @@ static bool parse_proc_stat(pid_t pid, char **outname, pid_t *outppid) {
 }
 
 static char *format_for_process(const char *name) {
-    if (strcasecmp(name, "i3bar") == 0)
+    if (strcasecmp(name, "i3bar") == 0 || strcasecmp(name, "swaybar") == 0)
         return "i3bar";
     else if (strcasecmp(name, "dzen2") == 0)
         return "dzen2";


### PR DESCRIPTION
[sway](/SirCmpwn/sway) is a Wayland version of i3. Its version of i3bar, swaybar, supports the i3bar protocol.

This makes the format autodetection recognise swaybar, so sway users don't have to configure i3status to explicitly use the i3bar protocol to get colours.