### PR TITLE
add support for reading text files

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -316,6 +316,14 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t file_contents_opts[] = {
+        CFG_STR("path", NULL, CFGF_NONE),
+        CFG_STR("format", "%title: %contents", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t wireless_opts[] = {
         CFG_STR("format_up", "W: (%quality at %essid, %bitrate) %ip", CFGF_NONE),
         CFG_STR("format_down", "W: down", CFGF_NONE),
@@ -427,6 +435,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("general", general_opts, CFGF_NONE),
         CFG_SEC("run_watch", run_watch_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("path_exists", path_exists_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("file_contents", file_contents_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("wireless", wireless_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ethernet", ethernet_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("battery", battery_opts, CFGF_TITLE | CFGF_MULTI),
@@ -641,6 +650,12 @@ int main(int argc, char *argv[]) {
             CASE_SEC_TITLE("path_exists") {
                 SEC_OPEN_MAP("path_exists");
                 print_path_exists(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("file_contents") {
+                SEC_OPEN_MAP("file_contents");
+                print_file_contents(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"));
                 SEC_CLOSE_MAP;
             }
 

--- a/i3status.conf
+++ b/i3status.conf
@@ -20,6 +20,12 @@ order += "ethernet _first_"
 order += "battery 0"
 order += "load"
 order += "tztime local"
+order += "file_contents Unread"
+
+file_contents Unread {
+        path = "/run/user/1000/notmuch/unread"
+        format = "%title: %contents"
+}
 
 wireless _first_ {
         format_up = "W: (%quality at %essid) %ip"

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -206,6 +206,7 @@ const char *get_ip_addr(const char *interface);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
+void print_file_contents(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);
 void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -59,6 +59,12 @@ order += "cpu_temperature 0"
 order += "load"
 order += "tztime local"
 order += "tztime berlin"
+order += "file_contents Unread"
+
+file_contents Unread {
+        path = "/run/user/1000/notmuch/unread"
+        format = "%title: %contents"
+}
 
 wireless wlan0 {
         format_up = "W: (%quality at %essid, %bitrate) %ip"
@@ -208,6 +214,17 @@ disk "/" {
     format = "%avail"
 }
 -------------------------------------------------------------
+
+=== File Contents
+
+This module reads and displays file contents in i3status. The canonical example
+is to cache counts for emails somewhere on disk.
+
+*Example order*: +file_contents Unread+
+
+*Example path*: +path = "/run/user/1000/notmuch/unread"+
+
+*Example format*: +%title: %contents+
 
 === IPv6
 

--- a/src/print_file_contents.c
+++ b/src/print_file_contents.c
@@ -1,0 +1,48 @@
+// vim:ts=4:sw=4:expandtab
+#include <stdio.h>
+#include <string.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include "i3status.h"
+
+void print_file_contents(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format) {
+    struct stat st;
+    const char *walk;
+    char *outwalk = buffer;
+    char *fcontents = NULL;
+    const bool exists = (stat(path, &st) == 0);
+
+    if(exists) {
+      FILE *fd = fopen(path, "r");
+      fcontents = malloc(st.st_size * sizeof(char));
+      int res = fread(fcontents, sizeof(char), st.st_size, fd);
+      if(res != -1)
+        fcontents[res] = '\0';
+      (void)fclose(fd);
+    }
+
+    INSTANCE(path);
+
+    START_COLOR((exists ? "color_good" : "color_bad"));
+
+    for (walk = format; *walk != '\0'; walk++) {
+        if (*walk != '%') {
+            *(outwalk++) = *walk;
+            continue;
+        }
+        if (BEGINS_WITH(walk + 1, "title")) {
+            outwalk += sprintf(outwalk, "%s", title);
+            walk += strlen("title");
+        } else if (BEGINS_WITH(walk + 1, "contents")) {
+            outwalk += sprintf(outwalk, "%s", (exists ? fcontents : "?"));
+            walk += strlen("contents");
+        }
+    }
+
+    if(exists) free(fcontents);
+
+    END_COLOR;
+    OUTPUT_FULL_TEXT(buffer);
+}


### PR DESCRIPTION
Hello,

I would like to propose adding support for reading and displaying file contents in i3status. I can be used to read in cached data from disk, like mail counts or statistics in plain text.

Please let me know if there are any improvements I should make to the code.