### PR TITLE
Add command for custom shell commands

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -421,6 +421,12 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t cmd_opts[] = {
+        CFG_STR("cmd", "echo 'hello world'", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
@@ -434,6 +440,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("volume", volume_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ipv6", ipv6_opts, CFGF_NONE),
         CFG_SEC("time", time_opts, CFGF_NONE),
+        CFG_SEC("cmd", cmd_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("tztime", tztime_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ddate", ddate_opts, CFGF_NONE),
         CFG_SEC("load", load_opts, CFGF_NONE),
@@ -694,6 +701,13 @@ int main(int argc, char *argv[]) {
                 print_cpu_usage(json_gen, buffer, cfg_getstr(sec, "format"));
                 SEC_CLOSE_MAP;
             }
+
+            CASE_SEC("cmd") {
+                SEC_OPEN_MAP("cmd");
+                print_cmd(json_gen, buffer, cfg_getstr(sec, "cmd"));
+                SEC_CLOSE_MAP;
+            }
+
         }
         if (output_format == O_I3BAR) {
             yajl_gen_array_close(json_gen);

--- a/i3status.c
+++ b/i3status.c
@@ -707,7 +707,6 @@ int main(int argc, char *argv[]) {
                 print_cmd(json_gen, buffer, cfg_getstr(sec, "cmd"));
                 SEC_CLOSE_MAP;
             }
-
         }
         if (output_format == O_I3BAR) {
             yajl_gen_array_close(json_gen);

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -211,6 +211,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
+void print_cmd(yajl_gen json_gen, char *buffer, const char *cmd);
 bool process_runs(const char *path);
 int volume_pulseaudio(uint32_t sink_idx);
 bool pulse_initialize(void);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -494,6 +494,22 @@ volume master {
 }
 -------------------------------------------------------------
 
+=== Custom command
+
+Outputs the first line of the stdout of the given shell command passed to *sh
+-c*. Note that the last newline is automatically removed.
+
+*Example order*: +cmd quodlibet+
+
+*Example cmd*: +pkill -0 quodlibet && quodlibet --print-playing+
+
+*Example configuration*:
+-------------------------------------------------------------
+cmd quodlibet {
+	cmd = "pkill -0 quodlibet && quodlibet --print-playing"
+}
+-------------------------------------------------------------
+
 == Universal module options
 
 When using the i3bar output format, there are a few additional options that

--- a/src/print_cmd.c
+++ b/src/print_cmd.c
@@ -1,0 +1,25 @@
+// vim:ts=4:sw=4:expandtab
+#include <stdio.h>
+#include <string.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+
+#include "i3status.h"
+
+#define BUFSIZE 1024
+
+void print_cmd(yajl_gen json_gen, char *buffer, const char *cmd) {
+    char *outwalk = buffer;
+    char path[BUFSIZE];
+    FILE *fp;
+    fp = popen(cmd, "r");
+    fgets(path, sizeof(path)-1, fp);
+    pclose(fp);
+
+    char *nl = index(path, '\n');
+    if(nl != NULL){
+        *nl = '\0';
+    }
+    maybe_escape_markup(path, &outwalk);
+    OUTPUT_FULL_TEXT(buffer);
+}

--- a/src/print_cmd.c
+++ b/src/print_cmd.c
@@ -6,11 +6,9 @@
 
 #include "i3status.h"
 
-#define BUFSIZE 1024
-
 void print_cmd(yajl_gen json_gen, char *buffer, const char *cmd) {
     char *outwalk = buffer;
-    char path[BUFSIZE];
+    char path[1024];
     FILE *fp;
     fp = popen(cmd, "r");
     fgets(path, sizeof(path) - 1, fp);

--- a/src/print_cmd.c
+++ b/src/print_cmd.c
@@ -13,11 +13,11 @@ void print_cmd(yajl_gen json_gen, char *buffer, const char *cmd) {
     char path[BUFSIZE];
     FILE *fp;
     fp = popen(cmd, "r");
-    fgets(path, sizeof(path)-1, fp);
+    fgets(path, sizeof(path) - 1, fp);
     pclose(fp);
 
     char *nl = index(path, '\n');
-    if(nl != NULL){
+    if (nl != NULL) {
         *nl = '\0';
     }
     maybe_escape_markup(path, &outwalk);


### PR DESCRIPTION
This adds the possibility to show the output of a given shell command in the status output without the need no wrap `i3status`.