### PR TITLE
check_mail.py: more detailed report on IOError

### DIFF
--- a/contrib/check_mail.py
+++ b/contrib/check_mail.py
@@ -82,6 +82,9 @@ def check_mail(label, nomail, ignore, colors):
             else:
                 return nomail, colors[0]
 
+        except IOError, exception:
+            return '{0}: {1}'.format(name, exception.strerror), colors[2]
+
         except:
             pass
 


### PR DESCRIPTION
When user doesn't have permissions to access some file, he is better served by
exact error message python recieved then by statement "not a mailbox".