### PR TITLE
This removes the 'remaining' time when the battery is full, since the…

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -152,7 +152,7 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
         (void)snprintf(percentagebuf, sizeof(percentagebuf), "%.02f%s", percentage_remaining, pct_mark);
     }
 
-    if (present_rate > 0) {
+    if (present_rate > 0 && status != CS_FULL) {
         float remaining_time;
         int seconds, hours, minutes, seconds_remaining;
         if (status == CS_CHARGING)


### PR DESCRIPTION
… remaining time is always 00:00:00. When the battery is discharging, the remaining time will show up again if the user has set their format correctly.