### PR TITLE
Implement CPU frequency display for Linux and OpenBSD.

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -390,6 +390,12 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t cpufreq_opts[] = {
+        CFG_STR("format", "%MHz", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t temp_opts[] = {
         CFG_STR("format", "%degrees C", CFGF_NONE),
         CFG_STR("path", NULL, CFGF_NONE),
@@ -429,6 +435,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("wireless", wireless_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ethernet", ethernet_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("battery", battery_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("cpu_freq", cpufreq_opts, CFGF_NONE),
         CFG_SEC("cpu_temperature", temp_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("disk", disk_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("volume", volume_opts, CFGF_TITLE | CFGF_MULTI),
@@ -680,6 +687,12 @@ int main(int argc, char *argv[]) {
                              cfg_getstr(sec, "device"),
                              cfg_getstr(sec, "mixer"),
                              cfg_getint(sec, "mixer_idx"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("cpu_freq") {
+                SEC_OPEN_MAP("cpu_freq");
+                print_cpu_freq(json_gen, buffer, cfg_getstr(sec, "format"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -206,6 +206,7 @@ const char *get_ip_addr(const char *interface);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
+void print_cpu_freq(yajl_gen json_gen, char *buffer, const char *format);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);
 void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -362,6 +362,13 @@ is used.
 
 *Example path*: +/sys/class/power_supply/CMB1/uevent+
 
+=== CPU-Frequency
+Sums the frequency of all CPUs and outputs an average frequency in MHz.
+
+*Example order*: +cpu_freq+
+
+*Example format*: +%MHz+
+
 === CPU-Temperature
 
 Gets the temperature of the given thermal zone. It is possible to

--- a/src/print_cpu_freq.c
+++ b/src/print_cpu_freq.c
@@ -1,0 +1,112 @@
+// vim:ts=4:sw=4:expandtab
+#include <ctype.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+
+#include "i3status.h"
+
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#include <err.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
+#if defined(__DragonFly__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/sensors.h>
+#endif
+
+#if defined(__OpenBSD__)
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/sensors.h>
+#endif
+
+#if defined(__NetBSD__)
+#include <fcntl.h>
+#include <prop/proplib.h>
+#include <sys/envsys.h>
+#endif
+
+#define CPUINFOBUFSIZE 32
+
+/*
+ * Reads /proc/cpuinfo and returns an average (combined) load of all CPUs.
+ *
+ */
+void print_cpu_freq(yajl_gen json_gen, char *buffer, const char *format) {
+    const char *walk;
+    char *outwalk = buffer;
+    char cpu_freq[CPUINFOBUFSIZE] = {0};
+
+#if defined(LINUX)
+    size_t linesize = 0;
+    size_t n_cpu = 0;
+    ssize_t linelen = 0;
+    double mhz_ttl = 0.0;
+    char *line = NULL;
+    char *cpuinfo = "/proc/cpuinfo";
+    FILE *fp = NULL;
+
+    if ((fp = fopen(cpuinfo, "r")) == NULL)
+        goto error;
+
+    while ((linelen = getline(&line, &linesize, fp)) != -1) {
+        if (strncmp(line, "cpu MHz", 7) == 0) {
+            double MHz = 0;
+            char *tmp = strrchr(line, ':');
+
+            tmp[strcspn(tmp, "\n")] = '\0';
+            for (; !isdigit(*tmp); ++tmp)
+                ;
+
+            if (sscanf(tmp, "%lf", &MHz) != 1 || MHz < 1)
+                goto lnxerror;
+
+            mhz_ttl += MHz;
+            n_cpu++;
+        }
+    }
+    (void)snprintf(cpu_freq, CPUINFOBUFSIZE, "%.0f", mhz_ttl / n_cpu);
+lnxerror:
+    fclose(fp);
+    free(line);
+#elif defined(__DragonFly__)
+/* TODO To be implemented */
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+/* TODO To be implemented */
+#elif defined(__OpenBSD__)
+    /* Based on /usr/src/usr.sbin/apm.c code. */
+    /* XXX Need to check if this is a single CPU or avg of all CPUs. */
+    int cpuspeed = 0;
+    int cpuspeed_mib[] = {CTL_HW, HW_CPUSPEED};
+    size_t cpurspeed_sz = sizeof(cpuspeed);
+
+    if (sysctl(cpuspeed_mib, 2, &cpuspeed, &cpurspeed_sz, NULL, 0) < 0)
+        goto error;
+    (void)snprintf(cpu_freq, CPUINFOBUFSIZE, "%.0f", cpuspeed);
+#elif defined(__NetBSD__)
+/* TODO To be implemented */
+#endif
+    for (walk = format; *walk != '\0'; walk++) {
+        if (*walk != '%') {
+            *(outwalk++) = *walk;
+            continue;
+        }
+        if (BEGINS_WITH(walk + 1, "MHz")) {
+            outwalk += sprintf(outwalk, "%s", cpu_freq);
+            walk += strlen("MHz");
+        }
+    }
+
+    OUTPUT_FULL_TEXT(buffer);
+    return;
+error:
+    OUTPUT_FULL_TEXT("can't read cpu frequency");
+    (void)fputs("i3status: Cannot read CPU frequency.\n", stderr);
+}


### PR DESCRIPTION
This patch adds support for showing (an average) frequency of all CPUs.

Unfortunately **this doesn't work yet** and I fail to spot what I am missing, since the frequency column stays blank.

Tried to test this way:
i3config.conf:
`+  order += "cpu_freq"`

$ make clean all
$ ./i3status -c i3config.conf

but the frequency column stays blank. Tips welcome.

Thanks