### PR TITLE
Add & document quality_leading_character option for wireless

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -328,6 +328,7 @@ int main(int argc, char *argv[]) {
     cfg_opt_t wireless_opts[] = {
         CFG_STR("format_up", "W: (%quality at %essid, %bitrate) %ip", CFGF_NONE),
         CFG_STR("format_down", "W: down", CFGF_NONE),
+        CFG_STR("quality_leading_character", NULL, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -644,7 +645,7 @@ int main(int argc, char *argv[]) {
                     interface = first_eth_interface(NET_TYPE_WIRELESS);
                 if (interface == NULL)
                     interface = title;
-                print_wireless_info(json_gen, buffer, interface, cfg_getstr(sec, "format_up"), cfg_getstr(sec, "format_down"));
+                print_wireless_info(json_gen, buffer, interface, cfg_getstr(sec, "format_up"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "quality_leading_character"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -211,7 +211,7 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *format_time, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
 const char *get_ip_addr(const char *interface);
-void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
+void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down, const char *quality_leading_character);
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -291,7 +291,8 @@ There also is an option "format_down". You can hide the output with
 
 Gets the link quality, frequency and ESSID of the given wireless network
 interface. You can specify different format strings for the network being
-connected or not connected.
+connected or not connected. The quality is padded with leading zeroes by
+default; to pad with another leading character use +quality_leading_character=" "+.
 
 The special interface name `_first_` will be replaced by the first wireless
 network interface found on the system (excluding devices starting with "lo").

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -486,10 +486,11 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
                 if (info.quality_max) {
                     char *start = outwalk;
                     outwalk += sprintf(outwalk, "%03d%s", PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
-                    if (quality_leading_character != NULL && strlen(quality_leading_character)>0)
+                    if (quality_leading_character != NULL && strlen(quality_leading_character) > 0)
                         if (start[0] == '0') {
                             start[0] = *quality_leading_character;
-                            if (start[1] == '0') start[1] = *quality_leading_character;
+                            if (start[1] == '0')
+                                start[1] = *quality_leading_character;
                         }
                 } else
                     outwalk += sprintf(outwalk, "%d", info.quality);

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -450,7 +450,7 @@ error1:
     return 0;
 }
 
-void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down) {
+void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down, const char *quality_leading_character) {
     const char *walk;
     char *outwalk = buffer;
     wireless_info_t info;
@@ -483,9 +483,15 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
 
         if (BEGINS_WITH(walk + 1, "quality")) {
             if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY) {
-                if (info.quality_max)
+                if (info.quality_max) {
+                    char *start = outwalk;
                     outwalk += sprintf(outwalk, "%03d%s", PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
-                else
+                    if (quality_leading_character != NULL && strlen(quality_leading_character)>0)
+                        if (start[0] == '0') {
+                            start[0] = *quality_leading_character;
+                            if (start[1] == '0') start[1] = *quality_leading_character;
+                        }
+                } else
                     outwalk += sprintf(outwalk, "%d", info.quality);
             } else {
                 *(outwalk++) = '?';


### PR DESCRIPTION
I added this function to my local version, and it appears to be a fix for #25.

I don't currently have the capability to test the manpage (or changes), but the markdown is fairly straightforward so can't see it should be a problem.

The only significant unknown is whether to hoist the extra wireless code out of the info.quality_max test, but I'm not 100% sure when the other branch of the if is currently triggered, so have left it alone for now.
