### PR TITLE
Added status_unk to battery_info

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -360,6 +360,7 @@ int main(int argc, char *argv[]) {
         CFG_STR("format_down", "No battery", CFGF_NONE),
         CFG_STR("status_chr", "CHR", CFGF_NONE),
         CFG_STR("status_bat", "BAT", CFGF_NONE),
+        CFG_STR("status_unk", "UNK", CFGF_NONE),
         CFG_STR("status_full", "FULL", CFGF_NONE),
         CFG_STR("path", "/sys/class/power_supply/BAT%d/uevent", CFGF_NONE),
         CFG_INT("low_threshold", 30, CFGF_NONE),
@@ -661,7 +662,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("battery") {
                 SEC_OPEN_MAP("battery");
-                print_battery_info(json_gen, buffer, atoi(title), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getbool(sec, "integer_battery_capacity"), cfg_getbool(sec, "hide_seconds"));
+                print_battery_info(json_gen, buffer, atoi(title), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_unk"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getbool(sec, "integer_battery_capacity"), cfg_getbool(sec, "hide_seconds"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -170,6 +170,7 @@ char *pct_mark;
 
 typedef enum { CS_DISCHARGING,
                CS_CHARGING,
+               CS_UNKNOWN,
                CS_FULL } charging_status_t;
 
 /*
@@ -207,7 +208,7 @@ const char *first_eth_interface(const net_type_t type);
 
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
 void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);
-void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
+void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *format_time, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
 const char *get_ip_addr(const char *interface);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -76,6 +76,7 @@ battery 0 {
         format_down = "No battery"
         status_chr = "⚡ CHR"
         status_bat = "🔋 BAT"
+        status_unk = "? UNK"
         status_full = "☻ FULL"
         path = "/sys/class/power_supply/BAT%d/uevent"
         low_threshold = 10
@@ -315,7 +316,7 @@ network interface found on the system (excluding devices starting with "lo").
 
 === Battery
 
-Gets the status (charging, discharging, running), percentage, remaining
+Gets the status (charging, discharging, unknown, full), percentage, remaining
 time and power consumption (in Watts) of the given battery and when it's
 estimated to be empty. If you want to use the last full capacity instead of the
 design capacity (when using the design capacity, it may happen that your
@@ -339,10 +340,10 @@ colored red. The low_threshold type can be of threshold_type "time" or
 
 Optionally custom strings including any UTF-8 symbols can be used for different
 battery states. This makes it possible to display individual symbols
-for each state (charging, discharging, full)
+for each state (charging, discharging, unknown, full)
 Of course it will also work with special iconic fonts, such as FontAwesome.
-If any of this special status strings is omitted, the default (CHR, BAT, FULL)
-is used.
+If any of these special status strings are omitted, the default (CHR, BAT, UNK,
+FULL) is used.
 
 *Example order*: +battery 0+
 
@@ -353,6 +354,8 @@ is used.
 *Example status_chr*: +⚡ CHR+
 
 *Example status_bat*: +🔋 BAT+
+
+*Example status_unk*: +? UNK+
 
 *Example status_full*: +☻ FULL+
 

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -34,7 +34,7 @@
  * worn off your battery is.
  *
  */
-void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds) {
+void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds) {
     time_t empty_time;
     struct tm *empty_tm;
     char buf[1024];
@@ -64,7 +64,7 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
     INSTANCE(batpath);
 
 #define BATT_STATUS_NAME(status) \
-    (status == CS_CHARGING ? status_chr : (status == CS_DISCHARGING ? status_bat : status_full))
+    (status == CS_CHARGING ? status_chr : (status == CS_DISCHARGING ? status_bat : (status == CS_UNKNOWN ? status_unk : status_full)))
 
 #if defined(LINUX)
     if (!slurp(batpath, buf, sizeof(buf))) {
@@ -101,6 +101,10 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
             status = CS_CHARGING;
         else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Full"))
             status = CS_FULL;
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Discharging"))
+            status = CS_DISCHARGING;
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS="))
+            status = CS_UNKNOWN;
         else {
             /* The only thing left is the full capacity */
             if (last_full_capacity) {


### PR DESCRIPTION
Some batteries report "Unknown" for battery status where they have some form of alternate mode.  Mine for example switches to AC supply when the battery is at 80% (BIOS option for extended battery life) and a colleagues allows the use of an external battery.

As such the existing i3status reports discharging when it is not the case.  As there is unlikely to be more than one "unknown" mode per battery this modification adds a battery option of "status_unk"  with default %status value of "UNK" allowing users to identify and configure for their battery.

This will have different uses for different people - I  set it to show I am plugged in and not charging,  my colleague will show external (but not wall) power,  and many others would derive no benefit whatsoever.

Note:

  This has only been implemented for the Linux ifdef.  If this feature is not desired in the main repo there is no point adding support for systems I do not use;  if this is something that is desired I am able to source readouts / work on the code for the other systems (though do not have copies running).