### PR TITLE
Add CPU usage color thresholds

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -413,7 +413,10 @@ int main(int argc, char *argv[]) {
 
     cfg_opt_t usage_opts[] = {
         CFG_STR("format", "%usage", CFGF_NONE),
+        CFG_FLOAT("max_threshold", 200, CFGF_NONE),
+        CFG_FLOAT("degraded_threshold", 200, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_CUSTOM_SEPARATOR_OPT,
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
@@ -726,7 +729,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC("cpu_usage") {
                 SEC_OPEN_MAP("cpu_usage");
-                print_cpu_usage(json_gen, buffer, cfg_getstr(sec, "format"));
+                print_cpu_usage(json_gen, buffer, cfg_getstr(sec, "format"), cfg_getfloat(sec, "max_threshold"), cfg_getfloat(sec, "degraded_threshold"));
                 SEC_CLOSE_MAP;
             }
         }

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -216,7 +216,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);
 void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const char *path, const char *format, int);
-void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format);
+void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold, const float degraded_threshold);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -381,11 +381,24 @@ specified thermal zone is getting too hot. Defaults to 75 degrees C.
 
 === CPU Usage
 
-Gets the percentual CPU usage from +/proc/stat+ (Linux) or +sysctl(3)+ (FreeBSD/OpenBSD).
+Gets the percentual CPU usage from +/proc/stat+ (Linux) or +sysctl(3)+
+(FreeBSD/OpenBSD).
+
+It is possible to define a max_threshold that will color the load
+value red in case the CPU average over the last interval is getting
+higher than the configured threshold. Defaults to 200 (i.e. off).
+
+It is possible to define a degraded_threshold that will color the load
+value yellow in case the CPU average over the last interval is getting
+higher than the configured threshold.  Defaults to 150 (i.e. off).
 
 *Example order*: +cpu_usage+
 
 *Example format*: +%usage+
+
+*Example max_threshold*: +"200,0"+
+
+*Example degraded_threshold*: +"150,0"+
 
 === Load
 


### PR DESCRIPTION
CPU usage had previously not supported the color option.  Add support
for a "degraded" state above which the degraded color is used, and a
higher "bad" state above which the "bad" color is used.  One possible
use for these might be indicating whether one or all cores are
saturated.

Unlike the color settings for other, these are set high enough to be
disabled by default.  This is done because i3status determines CPU
usage over only the last display interval, which means that, a user
with a low refresh rate might see frequent, potentially-annoying color
changes.