### PR TITLE
Default configuration paths ordered the same way as i3. Fixes #129

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -229,12 +229,7 @@ static char *resolve_tilde(const char *path) {
 static char *get_config_path(void) {
     char *xdg_config_home, *xdg_config_dirs, *config_path;
 
-    /* 1: check the traditional path under the home directory */
-    config_path = resolve_tilde("~/.i3status.conf");
-    if (path_exists(config_path))
-        return config_path;
-
-    /* 2: check for $XDG_CONFIG_HOME/i3status/config */
+    /* 1: check for $XDG_CONFIG_HOME/i3status/config */
     if ((xdg_config_home = getenv("XDG_CONFIG_HOME")) == NULL)
         xdg_config_home = "~/.config";
 
@@ -247,15 +242,14 @@ static char *get_config_path(void) {
         return config_path;
     free(config_path);
 
-    /* 3: check the traditional path under /etc */
-    config_path = SYSCONFDIR "/i3status.conf";
-    if (path_exists(config_path))
-        return sstrdup(config_path);
-
-    /* 4: check for $XDG_CONFIG_DIRS/i3status/config */
+    /* 2: check for $XDG_CONFIG_DIRS/i3status/config */
     if ((xdg_config_dirs = getenv("XDG_CONFIG_DIRS")) == NULL)
         xdg_config_dirs = "/etc/xdg";
 
+    /* 3: check the traditional path under the home directory */
+    config_path = resolve_tilde("~/.i3status.conf");
+    if (path_exists(config_path))
+        return config_path;
     char *buf = strdup(xdg_config_dirs);
     char *tok = strtok(buf, ":");
     while (tok != NULL) {
@@ -271,6 +265,11 @@ static char *get_config_path(void) {
         tok = strtok(NULL, ":");
     }
     free(buf);
+
+    /* 4: check the traditional path under /etc */
+    config_path = SYSCONFDIR "/i3status.conf";
+    if (path_exists(config_path))
+        return sstrdup(config_path);
 
     die("Unable to find the configuration file (looked at "
         "~/.i3status.conf, $XDG_CONFIG_HOME/i3status/config, "

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -17,10 +17,10 @@ i3status [-c configfile] [-h] [-v]
 Specifies an alternate configuration file path. By default, i3status looks for
 configuration files in the following order:
 
-1. ~/.i3status.conf
-2. ~/.config/i3status/config (or $XDG_CONFIG_HOME/i3status/config if set)
-3. /etc/i3status.conf
-4. /etc/xdg/i3status/config (or $XDG_CONFIG_DIRS/i3status/config if set)
+1. ~/.config/i3status/config (or $XDG_CONFIG_HOME/i3status/config if set)
+2. /etc/xdg/i3status/config (or $XDG_CONFIG_DIRS/i3status/config if set)
+3. ~/.i3status.conf
+4. /etc/i3status.conf
 
 == DESCRIPTION
 


### PR DESCRIPTION
The change has been made for #129, matching i3status behavior on i3's. The man page has been updated as well to reflect the change.

I hope I didn't miss anything.

For information, strace of config parsing to confirm order is right:
```bash
$ strace -e trace=stat ./i3status 
[...]
stat("/home/emeric", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/home/emeric/.config/i3status/config", 0x7ffc9c8d66b0) = -1 ENOENT (No such file or directory)
stat("/home/emeric", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/home/emeric/.i3status.conf", 0x7ffc9c8d66b0) = -1 ENOENT (No such file or directory)
stat("/etc/xdg/i3status/config", 0x7ffc9c8d66b0) = -1 ENOENT (No such file or directory)
stat("/etc/i3status.conf", {st_mode=S_IFREG|0644, st_size=1265, ...}) = 0
```