### PR TITLE
Manpage: Subsection tzdata: Example config now matches to context

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -433,9 +433,10 @@ If you would like to use markup in this section, there is a separate
 
 *Example configuration (markup)*:
 -------------------------------------------------------------
-tztime time {
+tztime berlin {
 	format = "<span foreground='#ffffff'>time:</span> %time"
 	format_time = "%H:%M %Z"
+	timezone = "Europe/Berlin"
 }
 -------------------------------------------------------------
 


### PR DESCRIPTION
When I tried to configure a tzdata section to myself I noticed that the example configuration wasn't clear enough in the given context. 

I suggest this as a little improving.