### PR TITLE
Implement aggregates in print_battery_info

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -664,7 +664,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("battery") {
                 SEC_OPEN_MAP("battery");
-                print_battery_info(json_gen, buffer, atoi(title), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_unk"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getbool(sec, "integer_battery_capacity"), cfg_getbool(sec, "hide_seconds"));
+                print_battery_info(json_gen, buffer, (strcasecmp(title, "all") == 0 ? -1 : atoi(title)), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_unk"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getbool(sec, "integer_battery_capacity"), cfg_getbool(sec, "hide_seconds"));
                 SEC_CLOSE_MAP;
             }
 

--- a/i3status.conf
+++ b/i3status.conf
@@ -15,7 +15,7 @@ order += "ipv6"
 order += "disk /"
 order += "wireless _first_"
 order += "ethernet _first_"
-order += "battery 0"
+order += "battery all"
 order += "load"
 order += "tztime local"
 
@@ -30,7 +30,7 @@ ethernet _first_ {
         format_down = "E: down"
 }
 
-battery 0 {
+battery all {
         format = "%status %percentage %remaining"
 }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -168,11 +168,6 @@ char *pct_mark;
         }                                                                                      \
     } while (0)
 
-typedef enum { CS_DISCHARGING,
-               CS_CHARGING,
-               CS_UNKNOWN,
-               CS_FULL } charging_status_t;
-
 /*
  * The "min_width" module option may either be defined as a string or a number.
  */

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -336,6 +336,10 @@ colored red. The low_threshold type can be of threshold_type "time" or
 "percentage". So, if you configure low_threshold to 10 and threshold_type to
 "time", and your battery lasts another 9 minutes, it will be colored red.
 
+To show an aggregate of all batteries in the system, use "all" as the number. In
+this case (for Linux), the /sys path must contain the "%d" sequence. Otherwise,
+the number indicates the battery index as reported in /sys.
+
 Optionally custom strings including any UTF-8 symbols can be used for different
 battery states. This makes it possible to display individual symbols
 for each state (charging, discharging, unknown, full)
@@ -343,7 +347,9 @@ Of course it will also work with special iconic fonts, such as FontAwesome.
 If any of these special status strings are omitted, the default (CHR, BAT, UNK,
 FULL) is used.
 
-*Example order*: +battery 0+
+*Example order (for the first battery)*: +battery 0+
+
+*Example order (aggregate of all batteries)*: +battery all+
 
 *Example format*: +%status %remaining (%emptytime %consumption)+
 
@@ -361,7 +367,9 @@ FULL) is used.
 
 *Example threshold_type*: +time+
 
-*Example path*: +/sys/class/power_supply/CMB1/uevent+
+*Example path (%d replaced by title number)*: +/sys/class/power_supply/CMB%d/uevent+
+
+*Example path (ignoring the number)*: +/sys/class/power_supply/CMB1/uevent+
 
 === CPU-Temperature
 

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -65,21 +65,21 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
         if (*walk != '=')
             continue;
 
-        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW")) {
+        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW=")) {
             watt_as_unit = true;
             batt_info->remaining = atoi(walk + 1);
-        } else if (BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_NOW")) {
+        } else if (BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_NOW=")) {
             watt_as_unit = false;
             batt_info->remaining = atoi(walk + 1);
-        } else if (BEGINS_WITH(last, "POWER_SUPPLY_CURRENT_NOW"))
+        } else if (BEGINS_WITH(last, "POWER_SUPPLY_CURRENT_NOW="))
             batt_info->present_rate = abs(atoi(walk + 1));
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_VOLTAGE_NOW"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_VOLTAGE_NOW="))
             voltage = abs(atoi(walk + 1));
         /* on some systems POWER_SUPPLY_POWER_NOW does not exist, but actually
          * it is the same as POWER_SUPPLY_CURRENT_NOW but with μWh as
          * unit instead of μAh. We will calculate it as we need it
          * later. */
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_POWER_NOW"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_POWER_NOW="))
             batt_info->present_rate = abs(atoi(walk + 1));
         else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Charging"))
             batt_info->status = CS_CHARGING;
@@ -89,11 +89,11 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
             batt_info->status = CS_DISCHARGING;
         else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS="))
             batt_info->status = CS_UNKNOWN;
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_FULL_DESIGN") ||
-                 BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_FULL_DESIGN"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_FULL_DESIGN=") ||
+                 BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_FULL_DESIGN="))
             batt_info->full_design = atoi(walk + 1);
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_FULL") ||
-                 BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_FULL"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_FULL=") ||
+                 BEGINS_WITH(last, "POWER_SUPPLY_CHARGE_FULL="))
             batt_info->full_last = atoi(walk + 1);
     }
 


### PR DESCRIPTION
This allows Linux and NetBSD code to use the magic "battery -1" to show an aggregate of all batteries. It is useful e.g. on the Thinkpad T460s, which has two batteries.

A substantial amount of refactoring to make the code manageable and remove duplication between OSes. Hopefully split into sensible commits. I can't guarantee it preserves existing behavior, but hopefully it improves it rather than makes it worse.

Tested in Gentoo Linux on a T460s and FreeBSD, OpenBSD, NetBSD in VirtualBox. VirtualBox doesn't emulate ACPI fully, so I can't say e.g. the time estimates work. The code compiles and responds to state/percentage changes at least. The NetBSD code didn't even compile cleanly, so that's an improvement.

Changed files have been run through clang-format-3.7 -style=file.