### PR TITLE
Refactor color code and computation of seconds_remaining in print_battery_info

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -224,9 +224,6 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
     if (status != CS_CHARGING) {
         seconds_remaining = apm_info.minutes_left * 60;
     }
-
-    if (colorful_output)
-        END_COLOR;
 #elif defined(__NetBSD__)
     /*
      * Using envsys(4) via sysmon(4).


### PR DESCRIPTION
Refactorings for #140.

This should not change functionality. Only Linux and NetBSD uses `seconds_remaining_from_rate`. FreeBSD and OpenBSD reads it from the OS. For NetBSD, the shuffling of code means the `status = CS_FULL` assignment now happens before the check for `status == CS_DISCHARGING`. I don't think it matters in practice.