### PR TITLE
Not mounted disk without format_not_mounted printing dash. Fixes #147

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -249,9 +249,7 @@ is assumed to be "percentage_avail" and low_threshold to be set to 0, which
 implies no coloring at all.
 
 You can define a different format with the option "format_not_mounted"
-which is used if the path does not exist or is not a mount point. So you can just empty
-the output for the given path with adding +format_not_mounted=""+
-to the config section.
+which is used if the path does not exist or is not a mount point. Defaults to "".
 
 *Example order*: +disk /mnt/usbstick+
 

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -130,13 +130,15 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
 #else
     struct statvfs buf;
 
+    if (format_not_mounted == NULL) {
+        format_not_mounted = "";
+    }
+
     if (statvfs(path, &buf) == -1) {
         /* If statvfs errors, e.g., due to the path not existing,
          * we use the format for a not mounted device. */
-        if (format_not_mounted != NULL) {
-            format = format_not_mounted;
-        }
-    } else if (format_not_mounted != NULL) {
+        format = format_not_mounted;
+    } else {
         FILE *mntentfile = setmntent("/etc/mtab", "r");
         struct mntent *m;
         bool found = false;


### PR DESCRIPTION
I am not immensely happy with the verbosity of the if / else _en masse_, but here's a proposition that work fine with the following configuration file:
```yaml
order += "disk /"
order += "disk /notmounted/disk"
order += "disk /notmounted/disk/format"

disk "/" {
        format = "/ '%free' '%used' '%total' '%avail' '%percentage_free' '%percentage_used_of_avail' '%percentage_used' '%percentage_avail'"
}

disk "/notmounted/disk" {
        format = "/notmounted/disk '%free' '%used' '%total' '%avail' '%percentage_free' '%percentage_used_of_avail' '%percentage_used' '%percentage_avail'"
}

disk "/notmounted/disk/format" {
        format = "'%free' '%used' '%total' '%avail' '%percentage_free' '%percentage_used_of_avail' '%percentage_used' '%percentage_avail'"
    format_not_mounted = "/notmounted/disk/format is not mounted…"
}
```
Here's a sample output:
```bash
$ ./i3status -c notmounteddisk.conf 
/ '19.0 GiB' '4.4 GiB' '23.4 GiB' '17.8 GiB' '81.1%' '24.0%' '18.9%' '76.0%' | /notmounted/disk '–' '–' '–' '–' '–' '–' '–' '–' | /notmounted/disk/format is not mounted…
```
I also took the liberty of adding a the function `print_percentage` to factor the constants used in the related sprintf. I can remove that if you prefer that the PR sticks to the point.