### PR TITLE
Fix some compilation warnings on OpenBSD and NetBSD

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -272,10 +272,8 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
     /* iterate over the dictionary returned by the kernel */
     while ((obj = prop_object_iterator_next(iter)) != NULL) {
         /* skip this dict if it's not what we're looking for */
-        if ((strlen(prop_dictionary_keysym_cstring_nocopy(obj)) == strlen(sensor_desc)) &&
-            (strncmp(sensor_desc,
-                     prop_dictionary_keysym_cstring_nocopy(obj),
-                     strlen(sensor_desc)) != 0))
+        if (strcmp(sensor_desc,
+                   prop_dictionary_keysym_cstring_nocopy(obj)) != 0)
             continue;
 
         is_found = true;
@@ -300,26 +298,17 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
         while ((obj2 = prop_object_iterator_next(iter2)) != NULL) {
             obj3 = prop_dictionary_get(obj2, "description");
 
-            if (obj3 &&
-                strlen(prop_string_cstring_nocopy(obj3)) == 8 &&
-                strncmp("charging",
-                        prop_string_cstring_nocopy(obj3),
-                        8) == 0) {
+            if (obj3 == NULL)
+                continue;
+
+            if (strcmp("charging", prop_string_cstring_nocopy(obj3)) == 0) {
                 obj3 = prop_dictionary_get(obj2, "cur-value");
 
                 if (prop_number_integer_value(obj3))
                     batt_info->status = CS_CHARGING;
                 else
                     batt_info->status = CS_DISCHARGING;
-
-                continue;
-            }
-
-            if (obj3 &&
-                strlen(prop_string_cstring_nocopy(obj3)) == 6 &&
-                strncmp("charge",
-                        prop_string_cstring_nocopy(obj3),
-                        6) == 0) {
+            } else if (strcmp("charge", prop_string_cstring_nocopy(obj3)) == 0) {
                 obj3 = prop_dictionary_get(obj2, "cur-value");
                 obj4 = prop_dictionary_get(obj2, "max-value");
                 obj5 = prop_dictionary_get(obj2, "type");
@@ -330,44 +319,19 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
                 if (remaining == full_design)
                     is_full = true;
 
-                if (strncmp("Ampere hour",
-                            prop_string_cstring_nocopy(obj5),
-                            11) == 0)
+                if (strcmp("Ampere hour", prop_string_cstring_nocopy(obj5)) == 0)
                     watt_as_unit = false;
                 else
                     watt_as_unit = true;
-
-                continue;
-            }
-
-            if (obj3 &&
-                strlen(prop_string_cstring_nocopy(obj3)) == 14 &&
-                strncmp("discharge rate",
-                        prop_string_cstring_nocopy(obj3),
-                        14) == 0) {
+            } else if (strcmp("discharge rate", prop_string_cstring_nocopy(obj3)) == 0) {
                 obj3 = prop_dictionary_get(obj2, "cur-value");
                 batt_info->present_rate = prop_number_integer_value(obj3);
-                continue;
-            }
-
-            if (obj3 &&
-                strlen(prop_string_cstring_nocopy(obj3)) == 13 &&
-                strncmp("last full cap",
-                        prop_string_cstring_nocopy(obj3),
-                        13) == 0) {
+            } else if (strcmp("last full cap", prop_string_cstring_nocopy(obj3)) == 0) {
                 obj3 = prop_dictionary_get(obj2, "cur-value");
                 last_full_cap = prop_number_integer_value(obj3);
-                continue;
-            }
-
-            if (obj3 &&
-                strlen(prop_string_cstring_nocopy(obj3)) == 7 &&
-                strncmp("voltage",
-                        prop_string_cstring_nocopy(obj3),
-                        7) == 0) {
+            } else if (strcmp("voltage", prop_string_cstring_nocopy(obj3)) == 0) {
                 obj3 = prop_dictionary_get(obj2, "cur-value");
                 voltage = prop_number_integer_value(obj3);
-                continue;
             }
         }
         prop_object_iterator_release(iter2);

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -404,14 +404,14 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
         }
     }
 
-#define EAT_SPACE_FROM_OUTPUT_IF_NO_OUTPUT()              \
-    do {                                                  \
-        if (outwalk == prevoutwalk) {                     \
-            if (outwalk > buffer && isspace(outwalk[-1])) \
-                outwalk--;                                \
-            else if (isspace(*(walk + 1)))                \
-                walk++;                                   \
-        }                                                 \
+#define EAT_SPACE_FROM_OUTPUT_IF_NO_OUTPUT()                   \
+    do {                                                       \
+        if (outwalk == prevoutwalk) {                          \
+            if (outwalk > buffer && isspace((int)outwalk[-1])) \
+                outwalk--;                                     \
+            else if (isspace((int)*(walk + 1)))                \
+                walk++;                                        \
+        }                                                      \
     } while (0)
 
     for (walk = format; *walk != '\0'; walk++) {

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -10,6 +10,7 @@
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
 #include <sys/param.h>
 #include <sys/mount.h>
+#elif defined(__NetBSD__)
 #else
 #include <mntent.h>
 #endif
@@ -120,6 +121,11 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
     struct statfs buf;
 
     if (statfs(path, &buf) == -1)
+        return;
+#elif defined(__NetBSD__)
+    struct statvfs buf;
+
+    if (statvfs(path, &buf) == -1)
         return;
 #else
     struct statvfs buf;

--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -79,7 +79,7 @@ static int print_eth_speed(char *outwalk, const char *interface) {
     ethspeed = (desc->ifmt_string != NULL ? desc->ifmt_string : "?");
     return sprintf(outwalk, "%s", ethspeed);
 #elif defined(__OpenBSD__) || defined(__NetBSD__)
-    char *ethspeed;
+    const char *ethspeed;
     struct ifmediareq ifmr;
 
     (void)memset(&ifmr, 0, sizeof(ifmr));

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -57,6 +57,12 @@
 #define IW_ESSID_MAX_SIZE IEEE80211_NWID_LEN
 #endif
 
+#ifdef __NetBSD__
+#include <sys/types.h>
+#include <net80211/ieee80211.h>
+#define IW_ESSID_MAX_SIZE IEEE80211_NWID_LEN
+#endif
+
 #include "i3status.h"
 
 #define WIRELESS_INFO_FLAG_HAS_ESSID (1 << 0)

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -54,6 +54,7 @@
 #include <netinet/if_ether.h>
 #include <net80211/ieee80211.h>
 #include <net80211/ieee80211_ioctl.h>
+#define IW_ESSID_MAX_SIZE IEEE80211_NWID_LEN
 #endif
 
 #include "i3status.h"
@@ -423,7 +424,7 @@ error1:
         else
             len = IEEE80211_NWID_LEN + 1;
 
-        strncpy(&info->essid[0], nwid.i_nwid, len);
+        strncpy(&info->essid[0], (char *)nwid.i_nwid, len);
         info->essid[IW_ESSID_MAX_SIZE] = '\0';
         info->flags |= WIRELESS_INFO_FLAG_HAS_ESSID;
     }


### PR DESCRIPTION
This was a by-the-way on the path to #140.

These are the last commits with general improvements to the *BSD code. They should have no functional impact.