### PR TITLE
Add ability to find interfaces with partial name matches

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -642,9 +642,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("wireless") {
                 SEC_OPEN_MAP("wireless");
-                const char *interface = NULL;
-                if (strcasecmp(title, "_first_") == 0)
-                    interface = first_eth_interface(NET_TYPE_WIRELESS);
+                const char *interface = first_eth_interface(NET_TYPE_WIRELESS, title);
                 if (interface == NULL)
                     interface = title;
                 print_wireless_info(json_gen, buffer, interface, cfg_getstr(sec, "format_up"), cfg_getstr(sec, "format_down"));
@@ -653,9 +651,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("ethernet") {
                 SEC_OPEN_MAP("ethernet");
-                const char *interface = NULL;
-                if (strcasecmp(title, "_first_") == 0)
-                    interface = first_eth_interface(NET_TYPE_ETHERNET);
+                const char *interface = first_eth_interface(NET_TYPE_ETHERNET, title);
                 if (interface == NULL)
                     interface = title;
                 print_eth_info(json_gen, buffer, interface, cfg_getstr(sec, "format_up"), cfg_getstr(sec, "format_down"));

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -204,7 +204,7 @@ typedef enum {
     NET_TYPE_WIRELESS = 0,
     NET_TYPE_ETHERNET = 1
 } net_type_t;
-const char *first_eth_interface(const net_type_t type);
+const char *first_eth_interface(const net_type_t type, const char *title);
 
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
 void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);


### PR DESCRIPTION
Some tethering devices change their interface name on reboot or
creation.  This allows finding the first device with a substring of the
name by checking for the special string _first_<DEV NAME>.  _first_
without a partial <DEV NAME> is unchanged.

Signed-off-by: Liam R. Howlett <Liam.Howlett@WindRiver.com>