### PR TITLE
Pulse device may be specified by name (#126)

### DIFF
--- a/include/i3status.h
+++ b/include/i3status.h
@@ -217,7 +217,7 @@ void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, cons
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const float max_threshold);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
 bool process_runs(const char *path);
-int volume_pulseaudio(uint32_t sink_idx);
+int volume_pulseaudio(uint32_t sink_idx, const char *sink_name);
 bool pulse_initialize(void);
 
 /* socket file descriptor for general purposes */

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -487,10 +487,16 @@ or
 
  device = "pulse:N"
 
-where N is the index of the PulseAudio sink. If no sink is specified the
-default is used. If the device string is missing or is set to "default",
-PulseAudio will be tried if detected and will fallback to ALSA (Linux)
-or OSS (FreeBSD/OpenBSD).
+where N is the index or name of the PulseAudio sink. You can obtain the name of
+the sink with the following command:
+
+ $ pacmd list-sinks | grep name:
+            name: <alsa_output.pci-0000_00_14.2.analog-stereo>
+
+The name is what's inside the angle brackets, not including them. If no sink is
+specified the default sink is used. If the device string is missing or is set
+to "default", PulseAudio will be tried if detected and will fallback to ALSA
+(Linux) or OSS (FreeBSD/OpenBSD).
 
 *Example order*: +volume master+
 
@@ -514,6 +520,13 @@ volume master {
 	format = "♪: %volume"
 	format_muted = "♪: muted (%volume)"
 	device = "pulse:1"
+}
+-------------------------------------------------------------
+-------------------------------------------------------------
+volume master {
+	format = "♪: %volume"
+	format_muted = "♪: muted (%volume)"
+	device = "pulse:alsa_output.pci-0000_00_14.2.analog-stereo"
 }
 -------------------------------------------------------------
 


### PR DESCRIPTION
Implements #126 
Using the default sink (by not specifying a sink) still works as before, i.e., if you change the default sink from device A to device B it changes the volume displayed to device B. On any other situation (if you specify the sink by id or name), it should follow that device even if it changes sink id. Of course if you specify by id it won't survive an i3status restart, so specifying the sink by name is better.