### PR TITLE
Use glob to get all batteries

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -104,7 +104,7 @@ static void *scalloc(size_t size) {
     return result;
 }
 
-static char *sstrdup(const char *str) {
+char *sstrdup(const char *str) {
     char *result = strdup(str);
     exit_if_null(result, "Error: out of memory (strdup())\n");
     return result;

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -176,6 +176,8 @@ struct min_width {
     const char *str;
 };
 
+char *sstrdup(const char *str);
+
 /* src/general.c */
 char *skip_character(char *input, char character, int amount);
 void die(const char *fmt, ...);


### PR DESCRIPTION
It seems that on many laptops BAT1 is present instead of BAT0. The change takes care of this very common case.