### PR TITLE
Allow to build without pulseaudio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,10 @@ CFLAGS += -idirafter yajl-fallback
 OBJS:=$(wildcard src/*.c *.c)
 OBJS:=$(OBJS:.c=.o)
 
-ifeq ($(OS),OpenBSD)
+ifdef NO_PULSEAUDIO
 OBJS:=$(filter-out src/pulse.o, $(OBJS))
 LIBS:=$(filter-out -lpulse, $(LIBS))
+CPPFLAGS+=-DNO_PULSEAUDIO=1
 endif
 
 src/%.o: src/%.c include/i3status.h

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -61,7 +61,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         free(instance);
     }
 
-#ifndef __OpenBSD__
+#ifndef NO_PULSEAUDIO
     /* Try PulseAudio first */
 
     /* If the device name has the format "pulse[:N]" where N is the


### PR DESCRIPTION
Instead of cherrypick OS that may or may not want pulseaudio, allow
to disable pulse by pass NO_PULSEAUDIO=1 to make