### PR TITLE
Fix i3status to compile with -fno-common

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -71,6 +71,11 @@ void **cur_instance;
 
 pthread_t main_thread;
 
+markup_format_t markup_format;
+output_format_t output_format;
+
+char *pct_mark;
+
 /*
  * Set the exit_upon_signal flag, because one cannot do anything in a safe
  * manner in a signal handler (e.g. fprintf, which we really want to do for

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -1,17 +1,23 @@
 #ifndef _I3STATUS_H
 #define _I3STATUS_H
 
-enum { O_DZEN2,
-       O_XMOBAR,
-       O_I3BAR,
-       O_LEMONBAR,
-       O_TERM,
-       O_NONE } output_format;
+typedef enum {
+    O_DZEN2,
+    O_XMOBAR,
+    O_I3BAR,
+    O_LEMONBAR,
+    O_TERM,
+    O_NONE
+} output_format_t;
+extern output_format_t output_format;
 
-enum { M_PANGO,
-       M_NONE } markup_format;
+typedef enum {
+    M_PANGO,
+    M_NONE
+} markup_format_t;
+extern markup_format_t markup_format;
 
-char *pct_mark;
+extern char *pct_mark;
 
 #include <stdbool.h>
 #include <confuse.h>


### PR DESCRIPTION
This avoids multiple declarations of the same global variable in
different source files.