### PR TITLE
Include sys/select.h on OpenBSD

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -49,6 +49,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <net/if.h>
+#include <sys/select.h>
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/if_ether.h>


### PR DESCRIPTION
Fixes a compilation error:
```
/usr/include/net80211/ieee80211_ioctl.h:339: warning: implicit declaration of function 'howmany'
/usr/include/net80211/ieee80211_ioctl.h:339: error: 'NBBY' undeclared here (not in a function)
/usr/include/net80211/ieee80211_ioctl.h:339: error: variably modified 'nr_rxmcs' at file scope
```