### PR TITLE
Allow to print IPv6 addresses in ethernet and wireless modules

### DIFF
--- a/include/i3status.h
+++ b/include/i3status.h
@@ -215,7 +215,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
 void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
-const char *get_ip_addr(const char *interface);
+const char *get_ip_addr(const char *interface, unsigned family);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_run_watch(yajl_gen json_gen, char *buffer, const char *title, const char *pidfile, const char *format, const char *format_down);
 void print_path_exists(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_down);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -300,7 +300,7 @@ network interface found on the system (excluding devices starting with "lo").
 
 *Example order*: +wireless wlan0+
 
-*Example format*: +W: (%quality at %essid, %bitrate / %frequency) %ip+
+*Example format*: +W: (%quality at %essid, %bitrate / %frequency) %ip [%ip6]+
 
 === Ethernet
 
@@ -313,7 +313,7 @@ network interface found on the system (excluding devices starting with "lo").
 
 *Example order*: +ethernet eth0+
 
-*Example format*: +E: %ip (%speed)+
+*Example format*: +E: %ip [%ip6] (%speed)+
 
 === Battery
 

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -471,8 +471,8 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
 
     INSTANCE(interface);
 
-    const char *ip_address = get_ip_addr(interface);
-    if (ip_address == NULL) {
+    const char *ip_address = get_ip_addr(interface, AF_INET);
+    if (ip_address == NULL) {  // Interface was down or not found
         START_COLOR("color_bad");
         outwalk += sprintf(outwalk, "%s", format_down);
         goto out;
@@ -549,8 +549,15 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
             walk += strlen("frequency");
         }
 
+        if (BEGINS_WITH(walk + 1, "ip6")) {
+            const char *ip6_address = get_ip_addr(interface, AF_INET6);
+            outwalk += sprintf(outwalk, "%s", ip6_address);
+            walk += strlen("ip");
+        }
+
         if (BEGINS_WITH(walk + 1, "ip")) {
-            outwalk += sprintf(outwalk, "%s", ip_address);
+            const char *ip4_address = get_ip_addr(interface, AF_INET);
+            outwalk += sprintf(outwalk, "%s", ip4_address);
             walk += strlen("ip");
         }
 


### PR DESCRIPTION
Mentioned in issue #205, this allows format like:

    format_up = "eth: %ip [%ip6] (%speed)"

This works for the ethernet and the wireless modules.