### PR TITLE
Show IP address when address has a label

### DIFF
--- a/src/print_ip_addr.c
+++ b/src/print_ip_addr.c
@@ -29,6 +29,7 @@ const char *get_ip_addr(const char *interface, int family) {
 
     struct ifaddrs *ifaddr, *addrp;
     bool found = false;
+    int interface_len = strlen(interface);
 
     getifaddrs(&ifaddr);
 
@@ -39,13 +40,13 @@ const char *get_ip_addr(const char *interface, int family) {
     for (addrp = ifaddr;
 
          (addrp != NULL &&
-          (strcmp(addrp->ifa_name, interface) != 0 ||
+          (strncmp(addrp->ifa_name, interface, interface_len) != 0 ||
            addrp->ifa_addr == NULL ||
            addrp->ifa_addr->sa_family != family));
 
          addrp = addrp->ifa_next) {
         /* Check if the interface is down */
-        if (strcmp(addrp->ifa_name, interface) != 0)
+        if (strncmp(addrp->ifa_name, interface, interface_len) != 0)
             continue;
         found = true;
         if ((addrp->ifa_flags & IFF_RUNNING) == 0) {


### PR DESCRIPTION
If an address has been added with a label, ensure the correct address is shown.

If a user has added a address with a description (e.g. `ip link addr add <addr>/<mask> dev <iface> label <iface>:<description>`) to the link "no IP" will be returned by `get_ip_addr`.

**Note:** Think of this more as an issue with a possible patch than an actual PR. Comments, critiques, and/or closing this PR for another fix are welcomed. I use `i3status` and hit this issue. There are definitely other (likely better) ways to solve this problem. For example, if the config could accept a label that would also solve the problem. AFAIK `get_ip_addr` would return the right address given `"<iface>:<label>"`