### PR TITLE
Add support for more hardware

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -323,8 +323,9 @@ estimated to be empty. If you want to use the last full capacity instead of the
 design capacity (when using the design capacity, it may happen that your
 battery is at 23% when fully charged because it’s old. In general, I want to
 see it this way, because it tells me how worn off my battery is.), just specify
-+last_full_capacity = true+. You can hide seconds in the remaining time and
-empty time estimations by setting +hide_seconds = true+.
++last_full_capacity = true+. Systems which do not measure a designed capacity
+will assume +last_full_capacity = true+. You can hide seconds in the remaining
+time and empty time estimations by setting +hide_seconds = true+.
 
 If you want the battery percentage to be shown without decimals, add
 +integer_battery_capacity = true+.

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -135,8 +135,7 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
         if (*walk != '=')
             continue;
 
-        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW=")
-         || BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_AVG=")) {
+        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW=") || BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_AVG=")) {
             watt_as_unit = true;
             batt_info->remaining = atoi(walk + 1);
             batt_info->percentage_remaining = -1;

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -135,7 +135,8 @@ static bool slurp_battery_info(struct battery_info *batt_info, yajl_gen json_gen
         if (*walk != '=')
             continue;
 
-        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW=")) {
+        if (BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_NOW=")
+         || BEGINS_WITH(last, "POWER_SUPPLY_ENERGY_AVG=")) {
             watt_as_unit = true;
             batt_info->remaining = atoi(walk + 1);
             batt_info->percentage_remaining = -1;
@@ -499,7 +500,9 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
             return;
     }
 
-    int full = (last_full_capacity ? batt_info.full_last : batt_info.full_design);
+    /* Some notebook batteries (eg. iBook G4) do not specify the design capacity,
+     * in which case, the last full capacity should be used instead */
+    int full = (last_full_capacity || batt_info.full_design < 0) ? batt_info.full_last : batt_info.full_design;
     if (full < 0 && batt_info.percentage_remaining < 0) {
         /* We have no physical measurements and no estimates. Nothing
          * much we can report, then. */


### PR DESCRIPTION
This PR encompasses two, very minor, changes to how the `print_battery_info` function works.

1. Not all battery hardware has a `POWER_SUPPLY_ENERGY_NOW` field, and in the case that it is not there `POWER_SUPPLY_ENERGY_AVG` is equivalent and can be substituted.
2. If battery hardware does not have a designed full capacity and only the last full capacity can be used, the (potentially default) setting for `last_full_capacity` should be ignored and the last full capacity should be used anyway, as to prevent an inevitable "No battery" message.

These two changes were made to allow support for the iBook G4's battery hardware, but I'm certain it applies to more that just that laptop (eg. other PowerBooks). It should not break compatibility with any other hardware.