### PR TITLE
Fixed-width wireless %bitrate, and 0-padded variants %quality0, %signal0, %noise0, %bitrate0

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -464,10 +464,15 @@ error1:
     return 0;
 }
 
+static const char *format_3d_s = "%3d%s";
+static const char *format_03d_s = "%03d%s";
+
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down) {
     const char *walk;
     char *outwalk = buffer;
     wireless_info_t info;
+    unsigned int advance;
+    const char *format;
 
     INSTANCE(interface);
 
@@ -496,15 +501,21 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         }
 
         if (BEGINS_WITH(walk + 1, "quality")) {
+            advance = strlen("quality");
             if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY) {
-                if (info.quality_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
-                else
+                if (info.quality_max) {
+                    format = format_3d_s;
+                    if (BEGINS_WITH(walk + advance + 1, "0")) {
+                        advance += strlen("0");
+                        format = format_03d_s;
+                    }
+                    outwalk += sprintf(outwalk, format, PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
+                } else
                     outwalk += sprintf(outwalk, "%d", info.quality);
             } else {
                 *(outwalk++) = '?';
             }
-            walk += strlen("quality");
+            walk += advance;
         }
 
         if (BEGINS_WITH(walk + 1, "signal")) {

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -519,27 +519,39 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         }
 
         if (BEGINS_WITH(walk + 1, "signal")) {
+            advance = strlen("signal");
             if (info.flags & WIRELESS_INFO_FLAG_HAS_SIGNAL) {
-                if (info.signal_level_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.signal_level, info.signal_level_max), pct_mark);
-                else
+                if (info.signal_level_max) {
+                    format = format_3d_s;
+                    if (BEGINS_WITH(walk + advance + 1, "0")) {
+                        advance += strlen("0");
+                        format = format_03d_s;
+                    }
+                    outwalk += sprintf(outwalk, format, PERCENT_VALUE(info.signal_level, info.signal_level_max), pct_mark);
+                } else
                     outwalk += sprintf(outwalk, "%d dBm", info.signal_level);
             } else {
                 *(outwalk++) = '?';
             }
-            walk += strlen("signal");
+            walk += advance;
         }
 
         if (BEGINS_WITH(walk + 1, "noise")) {
+            advance = strlen("noise");
             if (info.flags & WIRELESS_INFO_FLAG_HAS_NOISE) {
-                if (info.noise_level_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.noise_level, info.noise_level_max), pct_mark);
-                else
+                if (info.noise_level_max) {
+                    format = format_3d_s;
+                    if (BEGINS_WITH(walk + advance + 1, "0")) {
+                        advance += strlen("0");
+                        format = format_03d_s;
+                    }
+                    outwalk += sprintf(outwalk, format, PERCENT_VALUE(info.noise_level, info.noise_level_max), pct_mark);
+                } else
                     outwalk += sprintf(outwalk, "%d dBm", info.noise_level);
             } else {
                 *(outwalk++) = '?';
             }
-            walk += strlen("noise");
+            walk += advance;
         }
 
         if (BEGINS_WITH(walk + 1, "essid")) {


### PR DESCRIPTION
Possible implementation for #230 and #231.

I previously had a (terrible) go at this (http://cr.i3wm.org/patch/415/); I notice now that `print_bitrate()` has been included directly, making things a lot easier.

Not sure how you feel about the idea of appending `0` onto `%bitrate` et al to get zero-padded versions, but it seemed to me to be the best compromise between super-clean-but-invasive and super-dirty-hack.