### PR TITLE
Use local timezone for battery %emptytime

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -602,6 +602,7 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
         } else if (BEGINS_WITH(walk + 1, "emptytime")) {
             if (batt_info.seconds_remaining >= 0) {
                 time_t empty_time = time(NULL) + batt_info.seconds_remaining;
+                set_timezone(NULL); /* Use local time. */
                 struct tm *empty_tm = localtime(&empty_time);
 
                 if (hide_seconds)


### PR DESCRIPTION
This PR fixes #235 by using user timezone when printing `%emptytime`. It's the same in [print_ddate.c#L207](https://github.com/i3/i3status/blob/master/src/print_ddate.c#L207)