### PR TITLE
man: explicitly use format_up/format_down in ethernet, wireless conf

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -300,7 +300,9 @@ network interface found on the system (excluding devices starting with "lo").
 
 *Example order*: +wireless wlan0+
 
-*Example format*: +W: (%quality at %essid, %bitrate / %frequency) %ip+
+*Example format_up*: +W: (%quality at %essid, %bitrate / %frequency) %ip+
+
+*Example format_down*: +W: down+
 
 === Ethernet
 
@@ -313,7 +315,9 @@ network interface found on the system (excluding devices starting with "lo").
 
 *Example order*: +ethernet eth0+
 
-*Example format*: +E: %ip (%speed)+
+*Example format_up*: +E: %ip (%speed)+
+
+*Example format_down*: +E: down+
 
 === Battery
 


### PR DESCRIPTION
Clearly indicate format_up and format_down are used for configuring ethernet
and wireless sections instead of format.

Signed-off-by: Tomas Krizek <tomas.krizek@mailbox.org>