### PR TITLE
Call tzset at each time print

### DIFF
--- a/src/print_time.c
+++ b/src/print_time.c
@@ -29,9 +29,9 @@ void set_timezone(const char *tz) {
         } else {
             unsetenv("TZ");
         }
-        tzset();
         current_timezone = tz;
     }
+    tzset();
 }
 
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, time_t t) {


### PR DESCRIPTION
That syscall must be made at each time print since the timezone can be changed outside `i3status` and wouldn't be taken into account.

Fixes #223 and probably some other use cases.