### PR TITLE
Remove SLOC comment from man page

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -24,13 +24,12 @@ configuration files in the following order:
 
 == DESCRIPTION
 
-i3status is a small program (about 1500 SLOC) for generating a status bar for
-i3bar, dzen2, xmobar, lemonbar or similar programs. It is designed to be very
-efficient by issuing a very small number of system calls, as one generally
-wants to update such a status line every second. This ensures that even under
-high load, your status bar is updated correctly. Also, it saves a bit of energy
-by not hogging your CPU as much as spawning the corresponding amount of shell
-commands would.
+i3status is a small program for generating a status bar for i3bar, dzen2,
+xmobar, lemonbar or similar programs. It is designed to be very efficient by
+issuing a very small number of system calls, as one generally wants to update
+such a status line every second. This ensures that even under high load, your
+status bar is updated correctly. Also, it saves a bit of energy by not hogging
+your CPU as much as spawning the corresponding amount of shell commands would.
 
 == CONFIGURATION
 


### PR DESCRIPTION
This changed happened for the readme in
73620dc876d7f76b9a6771048c5ad0ade94e5bd7