### PR TITLE
Add check for interval value

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -631,6 +631,11 @@ int main(int argc, char *argv[]) {
         die("Could not create socket\n");
 
     int interval = cfg_getint(cfg_general, "interval");
+    if (interval <= 0) {
+        die("Invalid interval attribute found in section %s, line %d: %d\n"
+            "Expected positive integer\n",
+            cfg_general->name, cfg_general->line, interval);
+    }
 
     /* One memory page which each plugin can use to buffer output.
      * Even though it’s unclean, we just assume that the user will not


### PR DESCRIPTION
This PR adds a check for the interval value in the general section of the configuration.
A zero value generates a core dump on FreeBSD systems (division by zero):

```
$ cat i3status.conf
...
general {
        interval = 0
}
...

$ i3status -c i3status.conf
i3status: trying to auto-detect output_format setting
i3status: auto-detected "term"
♪: 80% | 0.12 | 2018-02-06 12:39:35
Floating point exception (core dumped)
```

With the patch applied:

```
$ i3status -c i3status.conf
i3status: trying to auto-detect output_format setting
i3status: auto-detected "term"
Invalid interval attribute found in section general, line 15: 0
Expected positive integer
```
Best Regards.