### PR TITLE
Make iface_type() work on FreeBSD

### DIFF
--- a/src/first_network_device.c
+++ b/src/first_network_device.c
@@ -14,10 +14,10 @@
 
 #include "i3status.h"
 
-#ifdef __linux__
-#define LOOPBACK_DEV "lo"
-#else
+#ifdef __OpenBSD__
 #define LOOPBACK_DEV "lo0"
+#else
+#define LOOPBACK_DEV "lo"
 #endif
 
 static bool sysfs_devtype(char *dest, size_t n, const char *ifnam) {
@@ -67,24 +67,7 @@ static bool is_virtual(const char *ifname) {
 }
 
 static net_type_t iface_type(const char *ifname) {
-#ifdef __linux__
-    char devtype[32];
-
-    if (!sysfs_devtype(devtype, sizeof(devtype), ifname))
-        return NET_TYPE_OTHER;
-
-    /* Default to Ethernet when no devtype is available */
-    if (!devtype[0])
-        return NET_TYPE_ETHERNET;
-
-    if (strcmp(devtype, "wlan") == 0)
-        return NET_TYPE_WIRELESS;
-
-    if (strcmp(devtype, "wwan") == 0)
-        return NET_TYPE_OTHER;
-
-    return NET_TYPE_OTHER;
-#elif __OpenBSD__
+#ifdef __OpenBSD__
     /*
      *First determine if the device is a wireless device by trying two ioctl(2)
      * commands against it. If either succeeds we can be sure it's a wireless
@@ -127,7 +110,22 @@ static net_type_t iface_type(const char *ifname) {
         return NET_TYPE_ETHERNET;
     }
 #else
-#error Missing implementation to determine interface type.
+    char devtype[32];
+
+    if (!sysfs_devtype(devtype, sizeof(devtype), ifname))
+        return NET_TYPE_OTHER;
+
+    /* Default to Ethernet when no devtype is available */
+    if (!devtype[0])
+        return NET_TYPE_ETHERNET;
+
+    if (strcmp(devtype, "wlan") == 0)
+        return NET_TYPE_WIRELESS;
+
+    if (strcmp(devtype, "wwan") == 0)
+        return NET_TYPE_OTHER;
+
+    return NET_TYPE_OTHER;
 #endif
 }
 


### PR DESCRIPTION
This PR should fix issues https://github.com/i3/i3status/issues/242 and https://github.com/i3/i3status/issues/243 by fixing https://github.com/i3/i3status/pull/197 PR which added compilation errors on FreeBSD systems.

Under FreeBSD, without this PR:

```
$ gmake
 CC i3status.c
 CC src/auto_detect_format.c
src/first_network_device.c:130:2: error: Missing implementation to determine interface type.
#error Missing implementation to determine interface type.
 ^
1 error generated.
gmake: *** [Makefile:89: src/first_network_device.o] Error 1
```

With this PR applied:

```
 CC i3status.c
 CC src/auto_detect_format.c
 CC src/first_network_device.c
 CC src/general.c
 CC src/output.c
 CC src/print_battery_info.c
 CC src/print_cpu_temperature.c
 CC src/print_cpu_usage.c
 CC src/print_ddate.c
 CC src/print_disk_info.c
 CC src/print_eth_info.c
 CC src/print_ip_addr.c
 CC src/print_ipv6_addr.c
 CC src/print_load.c
 CC src/print_path_exists.c
 CC src/print_run_watch.c
 CC src/print_time.c
 CC src/print_volume.c
src/print_wireless_info.c:612:5: warning: implicit declaration of function 'free' is invalid in C99 [-Wimplicit-function-declaration]
    free(ipv4_address);
    ^
1 warning generated.
 CC src/print_wireless_info.c
 CC src/process_runs.c
 CC src/pulse.c
 LD i3status
```

Best regards.