### PR TITLE
Print wireless quality without leading whitespace

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -539,7 +539,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         if (BEGINS_WITH(walk + 1, "quality")) {
             if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY) {
                 if (info.quality_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
+                    outwalk += sprintf(outwalk, "%d%s", PERCENT_VALUE(info.quality, info.quality_max), pct_mark);
                 else
                     outwalk += sprintf(outwalk, "%d", info.quality);
             } else {
@@ -551,7 +551,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         if (BEGINS_WITH(walk + 1, "signal")) {
             if (info.flags & WIRELESS_INFO_FLAG_HAS_SIGNAL) {
                 if (info.signal_level_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.signal_level, info.signal_level_max), pct_mark);
+                    outwalk += sprintf(outwalk, "%d%s", PERCENT_VALUE(info.signal_level, info.signal_level_max), pct_mark);
                 else
                     outwalk += sprintf(outwalk, "%d dBm", info.signal_level);
             } else {
@@ -563,7 +563,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         if (BEGINS_WITH(walk + 1, "noise")) {
             if (info.flags & WIRELESS_INFO_FLAG_HAS_NOISE) {
                 if (info.noise_level_max)
-                    outwalk += sprintf(outwalk, "%3d%s", PERCENT_VALUE(info.noise_level, info.noise_level_max), pct_mark);
+                    outwalk += sprintf(outwalk, "%d%s", PERCENT_VALUE(info.noise_level, info.noise_level_max), pct_mark);
                 else
                     outwalk += sprintf(outwalk, "%d dBm", info.noise_level);
             } else {


### PR DESCRIPTION
A config like
```
wireless wlan0 {
  format_up = "%ip (%quality)"
}
```
Will now result in something like `10.0.0.30 (85%)`
rather than `10.0.0.30 ( 85%)`

Also made this change for "signal" and "noise".