### PR TITLE
Added %raw %kernel %kernel_int CPU temp formatters

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -380,7 +380,9 @@ Gets the temperature of the given thermal zone. It is possible to
 define a max_threshold that will color the temperature red in case the
 specified thermal zone is getting too hot. Defaults to 75 degrees C. The
 output format when above max_threshold can be customized with
-format_above_threshold.
+format_above_threshold. Possible formats are %degrees (computed value),
+%raw (raw value as float), %kernel (raw value as published by the kernel)
+and %kernel_int (ditto but formatted as integer).
 
 *Example order*: +cpu_temperature 0+
 


### PR DESCRIPTION
The cpu_temperature can be easily used for reading values from sensors published via hwmon. I use that to read my Ryzen temperatures and fan speeds, which is much faster and lighter than spwaning sensors process. Here is my configuration for Ryzen 1700 on ASUS B150:

```
cpu_temperature CPUtemp {
  format = "CPU %degrees °C"
  path = "/sys/class/hwmon/hwmon1/temp1_input"
}

cpu_temperature CPUrpm {
  format = "%kernel_int RPM"
  path = "/sys/class/hwmon/hwmon2/fan1_input"
}

cpu_temperature GPUtemp {
  format = "GPU %degrees °C"
  path = "/sys/class/hwmon/hwmon0/temp1_input"
}

cpu_temperature GPUrpm {
  format = "%kernel_int RPM"
  path = "/sys/class/hwmon/hwmon0/fan1_input"
}

```

This patch adds new formatting options `%raw`, `%kernel` and `%kernel_int` so these values can be displayed accordingly. While this perhaps is not the best use of cpu_temperature it can be still useful for others, for example on unsupported platforms, users are still able to display something until there is a patch.