### PR TITLE
Fix MacOS build

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -16,6 +16,7 @@
 #endif
 
 #ifdef __APPLE__
+#include <sys/socket.h>
 #define IW_ESSID_MAX_SIZE 32
 #endif
 


### PR DESCRIPTION
This fixes #280. Note that compiling on MacOS requires installing `pulseaudio` using Homebrew for instance.