### PR TITLE
Add a general and per-module default color configuration

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -144,12 +144,13 @@ read_file uptime {
 === General
 
 The +colors+ directive will disable all colors if you set it to +false+. You can
-also specify the colors that will be used to display "good", "degraded" or "bad"
-values using the +color_good+, +color_degraded+ or +color_bad+ directives,
-respectively. Those directives are only used if color support is not disabled by
-the +colors+ directive. The input format for color values is the canonical RGB
-hexadecimal triplet (with no separators between the colors), prefixed by a hash
-character ("#").
+also specify the colors that will be used to display "default", "good",
+"degraded" or "bad" values using the +color_default+, +color_good+,
++color_degraded+ or +color_bad+ directives, respectively. Those directives are
+only used if color support is not disabled by the +colors+ directive. The input
+format for color values is the canonical RGB hexadecimal triplet (with no
+separators between the colors) prefixed by a hash character ("#"), or an empty
+string to disable the color.
 
 *Example configuration*:
 -------------------------------------------------------------
@@ -193,10 +194,10 @@ none::
 Does not use any color codes. Separates values by the pipe symbol by default.
 This should be used with i3bar and can be used for custom scripts.
 
-It's also possible to use the +color_good+, +color_degraded+, +color_bad+
-directives to define specific colors per module. If one of these directives is
-defined in a module section its value will override the value defined in the
-general section just for this module.
+It's also possible to use the +color_default+, +color_good+, +color_degraded+,
++color_bad+ directives to define specific colors per module. If one of these
+directives is defined in a module section its value will override the value
+defined in the general section just for this module.
 
 If you don't fancy the vertical separators between modules i3status/i3bar
 uses by default, you can employ the +separator+ directive to configure how

--- a/src/output.c
+++ b/src/output.c
@@ -13,34 +13,68 @@
 #include "i3status.h"
 
 /*
- * Returns the correct color format for dzen (^fg(color)), xmobar (<fc=color>)
- * or lemonbar (%{Fcolor})
+ * Returns the correct color format for i3bar (color), dzen (^fg(color)), xmobar
+ * (<fc=color>), lemonbar (%{Fcolor}) or terminal (escape-sequence). Returns
+ * NULL if the color is disabled.
  *
  */
-char *color(const char *colorstr) {
-    static char colorbuf[32];
-    if (!cfg_getbool(cfg_general, "colors")) {
-        colorbuf[0] = '\0';
-        return colorbuf;
+const char *begin_color_str(output_color_t outcolor, bool try_cfg_section) {
+    if (!enable_colors || output_format == O_NONE) {
+        return NULL;
     }
+
+    const char *color_key = NULL;
+    switch (outcolor) {
+        case COLOR_DEFAULT:
+            color_key = "color_default";
+            break;
+        case COLOR_GOOD:
+            color_key = "color_good";
+            break;
+        case COLOR_BAD:
+            color_key = "color_bad";
+            break;
+        case COLOR_DEGRADED:
+            color_key = "color_degraded";
+            break;
+        case COLOR_SEPARATOR:
+            color_key = "color_separator";
+            break;
+    }
+    if (!color_key)
+        return NULL;
+
+    const char *color = NULL;
+    if (try_cfg_section && cfg_section)
+        color = cfg_getstr(cfg_section, color_key);
+    if (!color)
+        color = cfg_getstr(cfg_general, color_key);
+    if (!color || color[0] == '\0')
+        return NULL;
+
+    if (output_format == O_I3BAR)
+        return color;
+
+    static char colorbuf[32];
     if (output_format == O_DZEN2)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "^fg(%s)", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "^fg(%s)", color);
     else if (output_format == O_XMOBAR)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "<fc=%s>", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "<fc=%s>", color);
     else if (output_format == O_LEMONBAR)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "%%{F%s}", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "%%{F%s}", color);
     else if (output_format == O_TERM) {
         /* The escape-sequence for color is <CSI><col>;1m (bright/bold
          * output), where col is a 3-bit rgb-value with b in the
          * least-significant bit. We round the given color to the
          * nearist 3-bit-depth color and output the escape-sequence */
-        char *str = cfg_getstr(cfg_general, colorstr);
-        int col = strtol(str + 1, NULL, 16);
+        int col = strtol(color + 1, NULL, 16);
         int r = (col & (0xFF << 0)) / 0x80;
         int g = (col & (0xFF << 8)) / 0x8000;
         int b = (col & (0xFF << 16)) / 0x800000;
         col = (r << 2) | (g << 1) | b;
         (void)snprintf(colorbuf, sizeof(colorbuf), "\033[3%d;1m", col);
+    } else {
+        return NULL;
     }
     return colorbuf;
 }
@@ -49,7 +83,7 @@ char *color(const char *colorstr) {
  * Some color formats (xmobar) require to terminate colors again
  *
  */
-char *endcolor(void) {
+const char *end_color_str(void) {
     if (output_format == O_XMOBAR)
         return "</fc>";
     else if (output_format == O_TERM)
@@ -61,16 +95,10 @@ char *endcolor(void) {
 void print_separator(const char *separator) {
     if (output_format == O_I3BAR || strlen(separator) == 0)
         return;
-
-    if (output_format == O_DZEN2)
-        printf("^fg(%s)%s^fg()", cfg_getstr(cfg_general, "color_separator"), separator);
-    else if (output_format == O_XMOBAR)
-        printf("<fc=%s>%s</fc>", cfg_getstr(cfg_general, "color_separator"), separator);
-    else if (output_format == O_LEMONBAR)
-        printf("%%{F%s}%s%%{F-}", cfg_getstr(cfg_general, "color_separator"), separator);
-    else if (output_format == O_TERM)
-        printf("%s%s%s", color("color_separator"), separator, endcolor());
-    else if (output_format == O_NONE)
+    const char *colorstr = begin_color_str(COLOR_SEPARATOR, false);
+    if (colorstr)
+        printf("%s%s%s", colorstr, separator, end_color_str());
+    else
         printf("%s", separator);
 }
 

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -145,6 +145,7 @@ static void add_battery_info(struct battery_info *acc, const struct battery_info
 
 static bool slurp_battery_info(battery_info_ctx_t *ctx, struct battery_info *batt_info, yajl_gen json_gen, char *buffer, int number, const char *path, const char *format_down) {
     char *outwalk = buffer;
+    output_color_t outcolor = COLOR_DEFAULT;
 
 #if defined(__linux__)
     char buf[1024];
@@ -529,6 +530,7 @@ static bool slurp_battery_info(battery_info_ctx_t *ctx, struct battery_info *bat
 static bool slurp_all_batteries(battery_info_ctx_t *ctx, struct battery_info *batt_info, yajl_gen json_gen, char *buffer, const char *path, const char *format_down) {
 #if defined(__linux__)
     char *outwalk = buffer;
+    output_color_t outcolor = COLOR_DEFAULT;
     bool is_found = false;
 
     char *placeholder;
@@ -586,6 +588,7 @@ static bool slurp_all_batteries(battery_info_ctx_t *ctx, struct battery_info *ba
 
 void print_battery_info(battery_info_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     struct battery_info batt_info = {
         .full_design = -1,
         .full_last = -1,
@@ -595,7 +598,6 @@ void print_battery_info(battery_info_ctx_t *ctx) {
         .percentage_remaining = -1,
         .status = CS_UNKNOWN,
     };
-    bool colorful_output = false;
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__OpenBSD__)
     /* These OSes report battery stats in whole percent. */
@@ -658,11 +660,9 @@ void print_battery_info(battery_info_ctx_t *ctx) {
 
     if (batt_info.status == CS_DISCHARGING && ctx->low_threshold > 0) {
         if (batt_info.percentage_remaining >= 0 && strcasecmp(ctx->threshold_type, "percentage") == 0 && batt_info.percentage_remaining < ctx->low_threshold) {
-            START_COLOR("color_bad");
-            colorful_output = true;
+            outcolor = COLOR_BAD;
         } else if (batt_info.seconds_remaining >= 0 && strcasecmp(ctx->threshold_type, "time") == 0 && batt_info.seconds_remaining < 60 * ctx->low_threshold) {
-            START_COLOR("color_bad");
-            colorful_output = true;
+            outcolor = COLOR_BAD;
         }
     }
 
@@ -731,10 +731,6 @@ void print_battery_info(battery_info_ctx_t *ctx) {
     OUTPUT_FORMATTED;
     free(formatted);
     free(untrimmed);
-
-    if (colorful_output) {
-        END_COLOR;
-    }
 
     OUTPUT_FULL_TEXT(ctx->buf);
 }

--- a/src/print_cpu_temperature.c
+++ b/src/print_cpu_temperature.c
@@ -213,9 +213,9 @@ error_netbsd1:
  */
 void print_cpu_temperature_info(cpu_temperature_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
 #ifdef THERMAL_ZONE
     const char *selected_format = ctx->format;
-    bool colorful_output = false;
     char *thermal_zone;
     temperature_t temperature;
     temperature.raw_value = 0;
@@ -243,8 +243,7 @@ void print_cpu_temperature_info(cpu_temperature_ctx_t *ctx) {
         goto error;
 
     if (temperature.raw_value >= ctx->max_threshold) {
-        START_COLOR("color_bad");
-        colorful_output = true;
+        outcolor = COLOR_BAD;
         if (ctx->format_above_threshold != NULL)
             selected_format = ctx->format_above_threshold;
     }
@@ -258,11 +257,6 @@ void print_cpu_temperature_info(cpu_temperature_ctx_t *ctx) {
     char *formatted = format_placeholders(selected_format, &placeholders[0], num);
     OUTPUT_FORMATTED;
     free(formatted);
-
-    if (colorful_output) {
-        END_COLOR;
-        colorful_output = false;
-    }
 
     free(thermal_zone);
 

--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -73,6 +73,7 @@ void print_cpu_usage(cpu_usage_ctx_t *ctx) {
     const char *selected_format = ctx->format;
     const char *walk;
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     struct cpu_usage curr_all = {0, 0, 0, 0, 0};
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
     long diff_idle, diff_total;
@@ -80,7 +81,6 @@ void print_cpu_usage(cpu_usage_ctx_t *ctx) {
     int diff_idle, diff_total;
 #endif
     int diff_usage;
-    bool colorful_output = false;
 
 #if defined(__linux__)
 
@@ -185,13 +185,11 @@ void print_cpu_usage(cpu_usage_ctx_t *ctx) {
 #endif
 
     if (diff_usage >= ctx->max_threshold) {
-        START_COLOR("color_bad");
-        colorful_output = true;
+        outcolor = COLOR_BAD;
         if (ctx->format_above_threshold != NULL)
             selected_format = ctx->format_above_threshold;
     } else if (diff_usage >= ctx->degraded_threshold) {
-        START_COLOR("color_degraded");
-        colorful_output = true;
+        outcolor = COLOR_DEGRADED;
         if (ctx->format_above_degraded_threshold != NULL)
             selected_format = ctx->format_above_degraded_threshold;
     }
@@ -230,9 +228,6 @@ void print_cpu_usage(cpu_usage_ctx_t *ctx) {
     struct cpu_usage *temp_cpus = prev_cpus;
     prev_cpus = curr_cpus;
     curr_cpus = temp_cpus;
-
-    if (colorful_output)
-        END_COLOR;
 
     OUTPUT_FULL_TEXT(ctx->buf);
     return;

--- a/src/print_ddate.c
+++ b/src/print_ddate.c
@@ -94,6 +94,7 @@ struct disc_time *get_ddate(struct tm *current_tm) {
 
 void print_ddate(ddate_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     struct tm current_tm;
     struct disc_time *dt;
     set_timezone(NULL); /* Use local time. */

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -127,7 +127,7 @@ static bool below_threshold(struct statvfs buf, const char *prefix_type, const c
 void print_disk_info(disk_info_ctx_t *ctx) {
     const char *selected_format = ctx->format;
     char *outwalk = ctx->buf;
-    bool colorful_output = false;
+    output_color_t outcolor = COLOR_DEFAULT;
     bool mounted = false;
 
     INSTANCE(ctx->path);
@@ -183,8 +183,7 @@ void print_disk_info(disk_info_ctx_t *ctx) {
             ctx->format_not_mounted = "";
         selected_format = ctx->format_not_mounted;
     } else if (ctx->low_threshold > 0 && below_threshold(buf, ctx->prefix_type, ctx->threshold_type, ctx->low_threshold)) {
-        START_COLOR("color_bad");
-        colorful_output = true;
+        outcolor = COLOR_BAD;
         if (ctx->format_below_threshold != NULL)
             selected_format = ctx->format_below_threshold;
     }
@@ -228,9 +227,6 @@ void print_disk_info(disk_info_ctx_t *ctx) {
     char *formatted = format_placeholders(selected_format, &placeholders[0], num);
     OUTPUT_FORMATTED;
     free(formatted);
-
-    if (colorful_output)
-        END_COLOR;
 
     *outwalk = '\0';
     OUTPUT_FULL_TEXT(ctx->buf);

--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -147,6 +147,7 @@ void print_eth_info(eth_info_ctx_t *ctx) {
     const char *format = ctx->format_down;  // default format
 
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     size_t num = 0;
 
     INSTANCE(ctx->interface);
@@ -168,7 +169,7 @@ void print_eth_info(eth_info_ctx_t *ctx) {
     bool prefer_ipv4 = true;
     if (ipv4_address == NULL) {
         if (ipv6_address == NULL) {
-            START_COLOR("color_bad");
+            outcolor = COLOR_BAD;
             goto out;
         } else {
             prefer_ipv4 = false;
@@ -181,9 +182,9 @@ void print_eth_info(eth_info_ctx_t *ctx) {
 
     const char *ip_address = (prefer_ipv4) ? ipv4_address : ipv6_address;
     if (BEGINS_WITH(ip_address, "no IP")) {
-        START_COLOR("color_degraded");
+        outcolor = COLOR_DEGRADED;
     } else {
-        START_COLOR("color_good");
+        outcolor = COLOR_GOOD;
     }
 
     char string_ip[STRING_SIZE];
@@ -203,7 +204,6 @@ out : {
     OUTPUT_FORMATTED;
     free(formatted);
 
-    END_COLOR;
     free(ipv4_address);
     free(ipv6_address);
     OUTPUT_FULL_TEXT(ctx->buf);

--- a/src/print_file_contents.c
+++ b/src/print_file_contents.c
@@ -17,6 +17,7 @@
 void print_file_contents(file_contents_ctx_t *ctx) {
     const char *walk = ctx->format;
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     char *buf = scalloc(ctx->max_chars * sizeof(char) + 1);
 
     if (ctx->path == NULL) {
@@ -38,10 +39,10 @@ void print_file_contents(file_contents_ctx_t *ctx) {
             buf[n] = '\0';
         }
         (void)close(fd);
-        START_COLOR("color_good");
+        outcolor = COLOR_GOOD;
     } else if (errno != 0) {
         walk = ctx->format_bad;
-        START_COLOR("color_bad");
+        outcolor = COLOR_BAD;
     }
 
     // remove newline chars
@@ -70,6 +71,5 @@ void print_file_contents(file_contents_ctx_t *ctx) {
     free(formatted);
     free(buf);
 
-    END_COLOR;
     OUTPUT_FULL_TEXT(ctx->buf);
 }

--- a/src/print_ipv6_addr.c
+++ b/src/print_ipv6_addr.c
@@ -183,16 +183,16 @@ void print_ipv6_info(ipv6_info_ctx_t *ctx) {
             ? get_iface_addr(addr_string)
             : "";
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
 
     if (addr_string == NULL) {
-        START_COLOR("color_bad");
+        outcolor = COLOR_BAD;
         outwalk += sprintf(outwalk, "%s", ctx->format_down);
-        END_COLOR;
         OUTPUT_FULL_TEXT(ctx->buf);
         return;
     }
 
-    START_COLOR("color_good");
+    outcolor = COLOR_GOOD;
 
     placeholder_t placeholders[] = {
         {.name = "%ip", .value = addr_string},
@@ -203,6 +203,5 @@ void print_ipv6_info(ipv6_info_ctx_t *ctx) {
     OUTPUT_FORMATTED;
     free(formatted);
 
-    END_COLOR;
     OUTPUT_FULL_TEXT(ctx->buf);
 }

--- a/src/print_load.c
+++ b/src/print_load.c
@@ -13,19 +13,18 @@
 
 void print_load(load_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     /* Get load */
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(sun) || defined(__DragonFly__)
     double loadavg[3];
     const char *selected_format = ctx->format;
-    bool colorful_output = false;
 
     if (getloadavg(loadavg, 3) == -1)
         goto error;
 
     if (loadavg[0] >= ctx->max_threshold) {
-        START_COLOR("color_bad");
-        colorful_output = true;
+        outcolor = COLOR_BAD;
         if (ctx->format_above_threshold != NULL)
             selected_format = ctx->format_above_threshold;
     }
@@ -47,9 +46,6 @@ void print_load(load_ctx_t *ctx) {
     char *formatted = format_placeholders(selected_format, &placeholders[0], num);
     OUTPUT_FORMATTED;
     free(formatted);
-
-    if (colorful_output)
-        END_COLOR;
 
     *outwalk = '\0';
     OUTPUT_FULL_TEXT(ctx->buf);

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -88,10 +88,10 @@ static unsigned long memory_absolute(const char *mem_amount, const unsigned long
 
 void print_memory(memory_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
 
 #if defined(__linux__)
     const char *selected_format = ctx->format;
-    const char *output_color = NULL;
 
     int unread_fields = 6;
     unsigned long ram_total;
@@ -151,20 +151,18 @@ void print_memory(memory_ctx_t *ctx) {
     if (ctx->threshold_degraded) {
         const unsigned long threshold = memory_absolute(ctx->threshold_degraded, ram_total);
         if (ram_available < threshold) {
-            output_color = "color_degraded";
+            outcolor = COLOR_DEGRADED;
         }
     }
 
     if (ctx->threshold_critical) {
         const unsigned long threshold = memory_absolute(ctx->threshold_critical, ram_total);
         if (ram_available < threshold) {
-            output_color = "color_bad";
+            outcolor = COLOR_BAD;
         }
     }
 
-    if (output_color) {
-        START_COLOR(output_color);
-
+    if (outcolor != COLOR_DEFAULT) {
         if (ctx->format_degraded)
             selected_format = ctx->format_degraded;
     }
@@ -204,9 +202,6 @@ void print_memory(memory_ctx_t *ctx) {
     char *formatted = format_placeholders(selected_format, &placeholders[0], num);
     OUTPUT_FORMATTED;
     free(formatted);
-
-    if (output_color)
-        END_COLOR;
 
     OUTPUT_FULL_TEXT(ctx->buf);
 

--- a/src/print_path_exists.c
+++ b/src/print_path_exists.c
@@ -13,6 +13,7 @@
 void print_path_exists(path_exists_ctx_t *ctx) {
     const char *walk;
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     struct stat st;
     const bool exists = (stat(ctx->path, &st) == 0);
 
@@ -24,7 +25,7 @@ void print_path_exists(path_exists_ctx_t *ctx) {
 
     INSTANCE(ctx->path);
 
-    START_COLOR((exists ? "color_good" : "color_bad"));
+    outcolor = (exists ? COLOR_GOOD : COLOR_BAD);
 
     char string_status[STRING_SIZE];
 
@@ -39,6 +40,5 @@ void print_path_exists(path_exists_ctx_t *ctx) {
     OUTPUT_FORMATTED;
     free(formatted);
 
-    END_COLOR;
     OUTPUT_FULL_TEXT(ctx->buf);
 }

--- a/src/print_run_watch.c
+++ b/src/print_run_watch.c
@@ -13,6 +13,7 @@ void print_run_watch(run_watch_ctx_t *ctx) {
     bool running = process_runs(ctx->pidfile);
     const char *walk;
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
 
     if (running || ctx->format_down == NULL) {
         walk = ctx->format;
@@ -22,7 +23,7 @@ void print_run_watch(run_watch_ctx_t *ctx) {
 
     INSTANCE(ctx->pidfile);
 
-    START_COLOR((running ? "color_good" : "color_bad"));
+    outcolor = (running ? COLOR_GOOD : COLOR_BAD);
 
     char string_status[STRING_SIZE];
     snprintf(string_status, STRING_SIZE, "%s", (running ? "yes" : "no"));
@@ -34,6 +35,5 @@ void print_run_watch(run_watch_ctx_t *ctx) {
     const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
     char *formatted = format_placeholders(walk, &placeholders[0], num);
     OUTPUT_FORMATTED;
-    END_COLOR;
     OUTPUT_FULL_TEXT(ctx->buf);
 }

--- a/src/print_time.c
+++ b/src/print_time.c
@@ -39,6 +39,7 @@ void set_timezone(const char *tz) {
 
 void print_time(time_ctx_t *ctx) {
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     struct tm local_tm, tm;
 
     if (ctx->title != NULL)

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -513,6 +513,7 @@ error1:
 void print_wireless_info(wireless_info_ctx_t *ctx) {
     const char *walk;
     char *outwalk = ctx->buf;
+    output_color_t outcolor = COLOR_DEFAULT;
     wireless_info_t info;
 
     INSTANCE(ctx->interface);
@@ -534,10 +535,9 @@ void print_wireless_info(wireless_info_ctx_t *ctx) {
     bool prefer_ipv4 = true;
     if (ipv4_address == NULL) {
         if (ipv6_address == NULL) {
-            START_COLOR("color_bad");
+            outcolor = COLOR_BAD;
             outwalk += sprintf(outwalk, "%s", ctx->format_down);
 
-            END_COLOR;
             free(ipv4_address);
             free(ipv6_address);
             OUTPUT_FULL_TEXT(ctx->buf);
@@ -552,16 +552,16 @@ void print_wireless_info(wireless_info_ctx_t *ctx) {
     const char *ip_address = (prefer_ipv4) ? ipv4_address : ipv6_address;
     if (!get_wireless_info(ctx->interface, &info)) {
         walk = ctx->format_down;
-        START_COLOR("color_bad");
+        outcolor = COLOR_BAD;
     } else {
         walk = ctx->format_up;
         if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY)
-            START_COLOR((info.quality < info.quality_average ? "color_degraded" : "color_good"));
+            outcolor = (info.quality < info.quality_average ? COLOR_DEGRADED : COLOR_GOOD);
         else {
             if (BEGINS_WITH(ip_address, "no IP")) {
-                START_COLOR("color_degraded");
+                outcolor = COLOR_DEGRADED;
             } else {
-                START_COLOR("color_good");
+                outcolor = COLOR_GOOD;
             }
         }
     }
@@ -634,7 +634,6 @@ void print_wireless_info(wireless_info_ctx_t *ctx) {
     OUTPUT_FORMATTED;
     free(formatted);
 
-    END_COLOR;
     free(ipv4_address);
     free(ipv6_address);
     OUTPUT_FULL_TEXT(ctx->buf);


### PR DESCRIPTION
Add a new `color_default` configuration to emit a per-module default color.

If left unspecified, you get the old behavior: the non-good/degraded/bad state does not emit any color, and so you get your *bar program*'s default color.

If `color_default` is specified, in `general` for all modules, or per-module in their respective sections, then the module will emit this color when in non-good/degraded/bad state.

Any color (`color_default`, `color_good` etc.) can be set to an empty string to disable the color, reverting to the *bar program* default color.

Notes on the source code changes:

- Replaced `START_COLOR`/`END_COLOR` with a variable `outcolor` (similar to `outwalk`), typed with a enum `output_color_t`. I think it's easier to play with the color now, and it makes it clearer it's for the entire module (as opposed to starting a color mid-sentence).
- This effectively adds a 4th state to good/bad/degraded. I thought about merging default and good state (e.g. good state by default), but some modules seem to differentiate between the default and the good state.
