### PR TITLE
Testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ addons:
 script:
   - make -j
   - clang-format-3.5 -i $(find . -name "*.[ch]" | tr '\n' ' ') && git diff --exit-code || (echo 'Code was not formatted using clang-format!'; false)
-  - ./travis/run-tests.pl
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ i3status: ${OBJS}
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 	@echo " LD $@"
 
+test: i3status
+	LC_ALL=C ./travis/run-tests.pl
+
 clean:
 	rm -f *.o src/*.o
 

--- a/travis/run-tests.pl
+++ b/travis/run-tests.pl
@@ -39,6 +39,8 @@ sub TestCase {
         return 1;
     } else {
         say "Testing test case '", basename($dir), "'… ", BOLD, RED, "Failed!", RESET;
+        say "Expected: '$refres'";
+        say "Got: '$testres'";
         return 0;
     }
 }

--- a/travis/run-tests.pl
+++ b/travis/run-tests.pl
@@ -16,6 +16,7 @@ sub TestCase {
 
     my $conf = "$dir/i3status.conf";
     my $testres = `./i3status --run-once -c $conf`;
+    my $exitcode = $?;
     my $refres = "";
 
     if ( -f "@_/expected_output.txt") {
@@ -26,6 +27,11 @@ sub TestCase {
 
     if ( -f "@_/cleanup.pl") {
         system($EXECUTABLE_NAME, "@_/cleanup.pl", ($dir));
+    }
+
+    if ( $exitcode != 0 ) {
+        say "Testing test case '", basename($dir), "'… ", BOLD, RED, "Crash!", RESET;
+        return 0;
     }
 
     if ( "$testres" eq "$refres" ) {

--- a/travis/run-tests.pl
+++ b/travis/run-tests.pl
@@ -44,14 +44,16 @@ sub TestCase {
 }
 
 my $testcases = 'testcases';
-my $testresults = 1;
+my $testresults = 0;
 
 opendir(my $dir, $testcases) or die "Could not open directory $testcases: $!";
 
 while (my $entry = readdir($dir)) {
     next unless (-d "$testcases/$entry");
     next if ($entry =~ m/^\./);
-    $testresults = $testresults && TestCase("$testcases/$entry");
+    if (not TestCase("$testcases/$entry") ) {
+        $testresults = 1;
+    }
 }
 closedir($dir);
-exit 0;
+exit $testresults;


### PR DESCRIPTION
I wanted to write some tests for #285
This changes a few things in the testsuite:

- Run all tests, no matter if the previous had been successful or not
- Exposes the success in the exit-code, so travis and other scripts can have a reliable test if the testsuite actually fails or not
- Implement `make test`, so that `i3status` gets rebuilt before test by default. This makes switching branches much easier and you can run the tests locally on your computer
- Check if `i3status` crashed and also expose it. Stupid errors, which occur after the tested output are caught now, too!