### PR TITLE
Fix potential issues & avoid unnecessary instructions 

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -106,7 +106,7 @@ static bool path_exists(const char *path) {
 
 static void *scalloc(size_t size) {
     void *result = calloc(size, 1);
-    exit_if_null(result, "Error: out of memory (calloc(%zd))\n", size);
+    exit_if_null(result, "Error: out of memory (calloc(%zu))\n", size);
     return result;
 }
 
@@ -142,7 +142,7 @@ static int parse_min_width(cfg_t *context, cfg_opt_t *option, const char *value,
     long num = strtol(value, &end, 10);
 
     if (num < 0)
-        die("Invalid min_width attribute found in section %s, line %d: %d\n"
+        die("Invalid min_width attribute found in section %s, line %d: %ld\n"
             "Expected positive integer or string\n",
             context->name, context->line, num);
     else if (num == LONG_MIN || num == LONG_MAX || (end && *end != '\0'))

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -186,7 +186,8 @@ char *sstrdup(const char *str);
 
 /* src/general.c */
 char *skip_character(char *input, char character, int amount);
-void die(const char *fmt, ...);
+
+void die(const char *fmt, ...) __attribute__((format(printf, 1, 2), noreturn));
 bool slurp(const char *filename, char *destination, int size);
 
 /* src/output.c */

--- a/src/general.c
+++ b/src/general.c
@@ -51,12 +51,10 @@ char *skip_character(char *input, char character, int amount) {
  *
  */
 void die(const char *fmt, ...) {
-    char buffer[512];
     va_list ap;
     va_start(ap, fmt);
-    (void)vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    (void)vfprintf(stderr, fmt, ap);
     va_end(ap);
 
-    fprintf(stderr, "%s", buffer);
     exit(EXIT_FAILURE);
 }

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -459,8 +459,8 @@ static bool slurp_all_batteries(struct battery_info *batt_info, yajl_gen json_ge
             is_found = true;
             add_battery_info(batt_info, &batt_buf);
         }
+        globfree(&globbuf);
     }
-    globfree(&globbuf);
     free(globpath);
 
     if (!is_found) {

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -450,8 +450,11 @@ static bool slurp_all_batteries(struct battery_info *batt_info, yajl_gen json_ge
                 .present_rate = 0,
                 .status = CS_UNKNOWN,
             };
-            if (!slurp_battery_info(&batt_buf, json_gen, buffer, i, globbuf.gl_pathv[i], format_down))
+            if (!slurp_battery_info(&batt_buf, json_gen, buffer, i, globbuf.gl_pathv[i], format_down)) {
+                globfree(&globbuf);
+                free(globpath);
                 return false;
+            }
 
             is_found = true;
             add_battery_info(batt_info, &batt_buf);

--- a/src/print_cpu_temperature.c
+++ b/src/print_cpu_temperature.c
@@ -223,7 +223,7 @@ void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const
         asprintf(&thermal_zone, THERMAL_ZONE, zone);
     else {
         static glob_t globbuf;
-        if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) < 0)
+        if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) != 0)
             die("glob() failed\n");
         if (globbuf.gl_pathc == 0) {
             /* No glob matches, the specified path does not contain a wildcard. */

--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/types.h>
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #elif defined(__NetBSD__)

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -39,10 +39,9 @@ static int print_bytes_human(char *outwalk, uint64_t bytes) {
  *
  */
 static long memory_absolute(const long mem_total, const char *size) {
-    long mem_absolute = -1;
     char *endptr = NULL;
 
-    mem_absolute = strtol(size, &endptr, 10);
+    long mem_absolute = strtol(size, &endptr, 10);
 
     if (endptr) {
         while (endptr[0] != '\0' && isspace(endptr[0]))

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -151,7 +151,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
     snd_mixer_selem_id_set_index(sid, mixer_idx);
     snd_mixer_selem_id_set_name(sid, mixer);
     if (!(elem = snd_mixer_find_selem(m, sid))) {
-        fprintf(stderr, "i3status: ALSA: Cannot find mixer %s (index %i)\n",
+        fprintf(stderr, "i3status: ALSA: Cannot find mixer %s (index %u)\n",
                 snd_mixer_selem_id_get_name(sid), snd_mixer_selem_id_get_index(sid));
         snd_mixer_close(m);
         snd_mixer_selem_id_free(sid);

--- a/src/process_runs.c
+++ b/src/process_runs.c
@@ -24,7 +24,7 @@ bool process_runs(const char *path) {
     static glob_t globbuf;
     memset(pidbuf, 0, sizeof(pidbuf));
 
-    if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) < 0)
+    if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) != 0)
         die("glob() failed\n");
     if (globbuf.gl_pathc == 0) {
         /* No glob matches, the specified path does not contain a wildcard. */


### PR DESCRIPTION
Hi,

This pull request fixes the following issues discovered by reading the code and/or by enabling more compilation warnings:

* potential memory leak in `slurp_all_batteries()`
* invalid handling of errors when using `glob()`
* use of undefined macro `__OpenBSD__` when building with another OS
* undefined behavior when using `globfree()` after `glob()` failure.
* argument of `die()` and `fprintf()` not matching the requested format

In addition to that, the `die()` function and the `memory_absolute()` function got simplified by removing superfluous instructions.

Kind regards,
Olivier