### PR TITLE
Stop requiring CAP_NET_ADMIN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,6 @@ install:
 	install -m 755 -d $(DESTDIR)$(SYSCONFDIR)
 	install -m 755 -d $(DESTDIR)$(MANPREFIX)/share/man/man1
 	install -m 755 i3status $(DESTDIR)$(PREFIX)/bin/i3status
-	# Allow network configuration for getting the link speed
-	(which setcap && setcap cap_net_admin=ep $(DESTDIR)$(PREFIX)/bin/i3status) || true
 	install -m 644 i3status.conf $(DESTDIR)$(SYSCONFDIR)/i3status.conf
 	install -m 644 man/i3status.1 $(DESTDIR)$(MANPREFIX)/share/man/man1
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ i3status has the following dependencies:
   * libyajl-dev
   * libasound2-dev
   * libnl-genl-3-dev
-  * libcap2-bin (for getting network status without root permissions)
   * asciidoc (only for the documentation)
   * libpulse-dev (for getting the current volume using PulseAudio)
 
 On debian-based systems, the following line will install all requirements:
 ```bash
-apt-get install libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libcap2-bin libpulse-dev libnl-genl-3-dev
+apt-get install libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libpulse-dev libnl-genl-3-dev
 ```
 
 ## Upstream

--- a/i3status.conf
+++ b/i3status.conf
@@ -26,7 +26,6 @@ wireless _first_ {
 }
 
 ethernet _first_ {
-        # if you use %speed, i3status requires root privileges
         format_up = "E: %ip (%speed)"
         format_down = "E: down"
 }

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -66,7 +66,6 @@ wireless wlan0 {
 }
 
 ethernet eth0 {
-        # if you use %speed, i3status requires the cap_net_admin capability
         format_up = "E: %ip (%speed)"
         format_down = "E: down"
 }
@@ -315,8 +314,7 @@ network interface found on the system (excluding devices starting with "lo").
 
 Gets the IP address and (if possible) the link speed of the given ethernet
 interface. If no IPv4 address is available and an IPv6 address is, it will be
-displayed. Getting the link speed requires the cap_net_admin capability.
-Set it using +setcap cap_net_admin=ep $(which i3status)+.
+displayed.
 
 The special interface name `_first_` will be replaced by the first non-wireless
 network interface found on the system (excluding devices starting with "lo").

--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -33,7 +33,6 @@
 
 static int print_eth_speed(char *outwalk, const char *interface) {
 #if defined(LINUX)
-    /* This code path requires root privileges */
     int ethspeed = 0;
     struct ifreq ifr;
     struct ethtool_cmd ecmd;


### PR DESCRIPTION
Hi,

This pull request removes the now-unnecessary `CAP_NET_ADMIN` capacity from the `i3status` binary.

Querying an Ethernet interface speed has been allowed as a non-root user without this capacity since Linux kernel ~~2.6.36~~ (EDIT 2.6.37).

Speaking of which, I strongly recommend to run the following command as root to drop the capability from an installed `i3status` binary since it can be harmful from a security standpoint and is no longer needed.

```bash
setcap -r "$(which i3status)"
``` 

Kind regards,
Olivier