### PR TITLE
switch to clang 3.8 & ignore include sort order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ IndentWidth: 4
 PointerBindsToType: false
 ColumnLimit: 0
 SpaceBeforeParens: ControlStatements
+SortIncludes: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ addons:
     # xmlto pulls in a2x which we need for generating manpages from asciidoc.
     - xmlto
     - libcap2-bin
-    - clang-format-3.5
+    - clang-format-3.8
     - libllvm3.5
 script:
   - make -j
-  - clang-format-3.5 -i $(find . -name "*.[ch]" | tr '\n' ' ') && git diff --exit-code || (echo 'Code was not formatted using clang-format!'; false)
+  - clang-format-3.8 -i $(find . -name "*.[ch]" | tr '\n' ' ') && git diff --exit-code || (echo 'Code was not formatted using clang-format!'; false)
   - make test

--- a/i3status.c
+++ b/i3status.c
@@ -44,7 +44,8 @@
     CFG_STR_CB("align", NULL, CFGF_NONE, parse_align)
 
 #define CFG_COLOR_OPTS(good, degraded, bad)             \
-    CFG_STR("color_good", good, CFGF_NONE),             \
+    CFG_STR("color_good", good, CFGF_NONE)              \
+    ,                                                   \
         CFG_STR("color_degraded", degraded, CFGF_NONE), \
         CFG_STR("color_bad", bad, CFGF_NONE)
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -81,82 +81,82 @@ extern char *pct_mark;
 
 /* Macro which any plugin can use to output the full_text part (when the output
  * format is JSON) or just output to stdout (any other output format). */
-#define OUTPUT_FULL_TEXT(text)                                                                   \
-    do {                                                                                         \
-        /* Terminate the output buffer here in any case, so that it’s                          \
-         * not forgotten in the module */                                                        \
-        *outwalk = '\0';                                                                         \
-        if (output_format == O_I3BAR) {                                                          \
-            char *_markup = cfg_getstr(cfg_general, "markup");                                   \
-            yajl_gen_string(json_gen, (const unsigned char *) "markup", strlen("markup"));       \
-            yajl_gen_string(json_gen, (const unsigned char *)_markup, strlen(_markup));          \
-            yajl_gen_string(json_gen, (const unsigned char *) "full_text", strlen("full_text")); \
-            yajl_gen_string(json_gen, (const unsigned char *)text, strlen(text));                \
-        } else {                                                                                 \
-            printf("%s", text);                                                                  \
-        }                                                                                        \
+#define OUTPUT_FULL_TEXT(text)                                                                  \
+    do {                                                                                        \
+        /* Terminate the output buffer here in any case, so that it’s                         \
+         * not forgotten in the module */                                                       \
+        *outwalk = '\0';                                                                        \
+        if (output_format == O_I3BAR) {                                                         \
+            char *_markup = cfg_getstr(cfg_general, "markup");                                  \
+            yajl_gen_string(json_gen, (const unsigned char *)"markup", strlen("markup"));       \
+            yajl_gen_string(json_gen, (const unsigned char *)_markup, strlen(_markup));         \
+            yajl_gen_string(json_gen, (const unsigned char *)"full_text", strlen("full_text")); \
+            yajl_gen_string(json_gen, (const unsigned char *)text, strlen(text));               \
+        } else {                                                                                \
+            printf("%s", text);                                                                 \
+        }                                                                                       \
     } while (0)
 
-#define SEC_OPEN_MAP(name)                                                             \
-    do {                                                                               \
-        if (output_format == O_I3BAR) {                                                \
-            yajl_gen_map_open(json_gen);                                               \
-            yajl_gen_string(json_gen, (const unsigned char *) "name", strlen("name")); \
-            yajl_gen_string(json_gen, (const unsigned char *)name, strlen(name));      \
-        }                                                                              \
+#define SEC_OPEN_MAP(name)                                                            \
+    do {                                                                              \
+        if (output_format == O_I3BAR) {                                               \
+            yajl_gen_map_open(json_gen);                                              \
+            yajl_gen_string(json_gen, (const unsigned char *)"name", strlen("name")); \
+            yajl_gen_string(json_gen, (const unsigned char *)name, strlen(name));     \
+        }                                                                             \
     } while (0)
 
-#define SEC_CLOSE_MAP                                                                                                        \
-    do {                                                                                                                     \
-        if (output_format == O_I3BAR) {                                                                                      \
-            char *_align = cfg_getstr(sec, "align");                                                                         \
-            if (_align) {                                                                                                    \
-                yajl_gen_string(json_gen, (const unsigned char *) "align", strlen("align"));                                 \
-                yajl_gen_string(json_gen, (const unsigned char *)_align, strlen(_align));                                    \
-            }                                                                                                                \
-            struct min_width *_width = cfg_getptr(sec, "min_width");                                                         \
-            if (_width) {                                                                                                    \
-                /* if the value can be parsed as a number, we use the numerical value */                                     \
-                if (_width->num > 0) {                                                                                       \
-                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width"));                     \
-                    yajl_gen_integer(json_gen, _width->num);                                                                 \
-                } else {                                                                                                     \
-                    yajl_gen_string(json_gen, (const unsigned char *) "min_width", strlen("min_width"));                     \
-                    yajl_gen_string(json_gen, (const unsigned char *)_width->str, strlen(_width->str));                      \
-                }                                                                                                            \
-            }                                                                                                                \
-            if (cfg_size(sec, "separator") > 0) {                                                                            \
-                yajl_gen_string(json_gen, (const unsigned char *) "separator", strlen("separator"));                         \
-                yajl_gen_bool(json_gen, cfg_getbool(sec, "separator"));                                                      \
-            }                                                                                                                \
-            if (cfg_size(sec, "separator_block_width") > 0) {                                                                \
-                yajl_gen_string(json_gen, (const unsigned char *) "separator_block_width", strlen("separator_block_width")); \
-                yajl_gen_integer(json_gen, cfg_getint(sec, "separator_block_width"));                                        \
-            }                                                                                                                \
-            const char *_sep = cfg_getstr(cfg_general, "separator");                                                         \
-            if (strlen(_sep) == 0) {                                                                                         \
-                yajl_gen_string(json_gen, (const unsigned char *) "separator", strlen("separator"));                         \
-                yajl_gen_bool(json_gen, false);                                                                              \
-            }                                                                                                                \
-            yajl_gen_map_close(json_gen);                                                                                    \
-        }                                                                                                                    \
+#define SEC_CLOSE_MAP                                                                                                       \
+    do {                                                                                                                    \
+        if (output_format == O_I3BAR) {                                                                                     \
+            char *_align = cfg_getstr(sec, "align");                                                                        \
+            if (_align) {                                                                                                   \
+                yajl_gen_string(json_gen, (const unsigned char *)"align", strlen("align"));                                 \
+                yajl_gen_string(json_gen, (const unsigned char *)_align, strlen(_align));                                   \
+            }                                                                                                               \
+            struct min_width *_width = cfg_getptr(sec, "min_width");                                                        \
+            if (_width) {                                                                                                   \
+                /* if the value can be parsed as a number, we use the numerical value */                                    \
+                if (_width->num > 0) {                                                                                      \
+                    yajl_gen_string(json_gen, (const unsigned char *)"min_width", strlen("min_width"));                     \
+                    yajl_gen_integer(json_gen, _width->num);                                                                \
+                } else {                                                                                                    \
+                    yajl_gen_string(json_gen, (const unsigned char *)"min_width", strlen("min_width"));                     \
+                    yajl_gen_string(json_gen, (const unsigned char *)_width->str, strlen(_width->str));                     \
+                }                                                                                                           \
+            }                                                                                                               \
+            if (cfg_size(sec, "separator") > 0) {                                                                           \
+                yajl_gen_string(json_gen, (const unsigned char *)"separator", strlen("separator"));                         \
+                yajl_gen_bool(json_gen, cfg_getbool(sec, "separator"));                                                     \
+            }                                                                                                               \
+            if (cfg_size(sec, "separator_block_width") > 0) {                                                               \
+                yajl_gen_string(json_gen, (const unsigned char *)"separator_block_width", strlen("separator_block_width")); \
+                yajl_gen_integer(json_gen, cfg_getint(sec, "separator_block_width"));                                       \
+            }                                                                                                               \
+            const char *_sep = cfg_getstr(cfg_general, "separator");                                                        \
+            if (strlen(_sep) == 0) {                                                                                        \
+                yajl_gen_string(json_gen, (const unsigned char *)"separator", strlen("separator"));                         \
+                yajl_gen_bool(json_gen, false);                                                                             \
+            }                                                                                                               \
+            yajl_gen_map_close(json_gen);                                                                                   \
+        }                                                                                                                   \
     } while (0)
 
-#define START_COLOR(colorstr)                                                                \
-    do {                                                                                     \
-        if (cfg_getbool(cfg_general, "colors")) {                                            \
-            const char *_val = NULL;                                                         \
-            if (cfg_section)                                                                 \
-                _val = cfg_getstr(cfg_section, colorstr);                                    \
-            if (!_val)                                                                       \
-                _val = cfg_getstr(cfg_general, colorstr);                                    \
-            if (output_format == O_I3BAR) {                                                  \
-                yajl_gen_string(json_gen, (const unsigned char *) "color", strlen("color")); \
-                yajl_gen_string(json_gen, (const unsigned char *)_val, strlen(_val));        \
-            } else {                                                                         \
-                outwalk += sprintf(outwalk, "%s", color(colorstr));                          \
-            }                                                                                \
-        }                                                                                    \
+#define START_COLOR(colorstr)                                                               \
+    do {                                                                                    \
+        if (cfg_getbool(cfg_general, "colors")) {                                           \
+            const char *_val = NULL;                                                        \
+            if (cfg_section)                                                                \
+                _val = cfg_getstr(cfg_section, colorstr);                                   \
+            if (!_val)                                                                      \
+                _val = cfg_getstr(cfg_general, colorstr);                                   \
+            if (output_format == O_I3BAR) {                                                 \
+                yajl_gen_string(json_gen, (const unsigned char *)"color", strlen("color")); \
+                yajl_gen_string(json_gen, (const unsigned char *)_val, strlen(_val));       \
+            } else {                                                                        \
+                outwalk += sprintf(outwalk, "%s", color(colorstr));                         \
+            }                                                                               \
+        }                                                                                   \
     } while (0)
 
 #define END_COLOR                                                             \
@@ -166,12 +166,12 @@ extern char *pct_mark;
         }                                                                     \
     } while (0)
 
-#define INSTANCE(instance)                                                                     \
-    do {                                                                                       \
-        if (output_format == O_I3BAR) {                                                        \
-            yajl_gen_string(json_gen, (const unsigned char *) "instance", strlen("instance")); \
-            yajl_gen_string(json_gen, (const unsigned char *)instance, strlen(instance));      \
-        }                                                                                      \
+#define INSTANCE(instance)                                                                    \
+    do {                                                                                      \
+        if (output_format == O_I3BAR) {                                                       \
+            yajl_gen_string(json_gen, (const unsigned char *)"instance", strlen("instance")); \
+            yajl_gen_string(json_gen, (const unsigned char *)instance, strlen(instance));     \
+        }                                                                                     \
     } while (0)
 
 /*

--- a/include/queue.h
+++ b/include/queue.h
@@ -433,7 +433,10 @@
     }
 
 #define CIRCLEQ_HEAD_INITIALIZER(head) \
-    { CIRCLEQ_END(&head), CIRCLEQ_END(&head) }
+    {                                  \
+        CIRCLEQ_END(&head)             \
+        , CIRCLEQ_END(&head)           \
+    }
 
 #define CIRCLEQ_ENTRY(type)                           \
     struct {                                          \

--- a/src/pulse.c
+++ b/src/pulse.c
@@ -14,7 +14,8 @@ typedef struct indexed_volume_s {
     char *name;
     uint32_t idx;
     int volume;
-    TAILQ_ENTRY(indexed_volume_s) entries;
+    TAILQ_ENTRY(indexed_volume_s)
+    entries;
 } indexed_volume_t;
 
 static pa_threaded_mainloop *main_loop = NULL;
@@ -23,7 +24,8 @@ static pa_mainloop_api *api = NULL;
 static bool context_ready = false;
 static bool mainloop_thread_running = false;
 static uint32_t default_sink_idx = DEFAULT_SINK_INDEX;
-TAILQ_HEAD(tailhead, indexed_volume_s) cached_volume =
+TAILQ_HEAD(tailhead, indexed_volume_s)
+cached_volume =
     TAILQ_HEAD_INITIALIZER(cached_volume);
 static pthread_mutex_t pulse_mutex = PTHREAD_MUTEX_INITIALIZER;
 


### PR DESCRIPTION
my system is an arch-linux, so i am having a newer clang-version
everytime i make an `clang-format` i have to revert these changes.

so it would be easier for me if the includes have the right order