### PR TITLE
Do not use pulseaudio for DragonFly BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ OBJS:=$(filter-out src/pulse.o, $(OBJS))
 LIBS:=$(filter-out -lpulse, $(LIBS))
 endif
 
+ifeq ($(OS),DragonFly)
+OBJS:=$(filter-out src/pulse.o, $(OBJS))
+LIBS:=$(filter-out -lpulse, $(LIBS)) -lpthread
+endif
+
 src/%.o: src/%.c include/i3status.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 	@echo " CC $<"

--- a/src/print_volume.c
+++ b/src/print_volume.c
@@ -63,7 +63,7 @@ void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *
         free(instance);
     }
 
-#ifndef __OpenBSD__
+#if !defined(__DragonFly__) && !defined(__OpenBSD__)
     /* Try PulseAudio first */
 
     /* If the device name has the format "pulse[:N]" where N is the


### PR DESCRIPTION
We disable Pulseaudio in DPorts with this patch.