### PR TITLE
Detect interface type on DragonFly BSD

### DIFF
--- a/src/first_network_device.c
+++ b/src/first_network_device.c
@@ -3,13 +3,17 @@
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <ifaddrs.h>
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined(__DragonFly__)
 #include <sys/types.h>
 #include <sys/sockio.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
+#endif
+#if defined(__OpenBSD__)
 #include <net80211/ieee80211.h>
 #include <net80211/ieee80211_ioctl.h>
+#elif defined(__DragonFly__)
+#include <netproto/802_11/ieee80211_ioctl.h>
 #endif
 
 #include "i3status.h"
@@ -67,7 +71,7 @@ static bool is_virtual(const char *ifname) {
 }
 
 static net_type_t iface_type(const char *ifname) {
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__)
     /*
      *First determine if the device is a wireless device by trying two ioctl(2)
      * commands against it. If either succeeds we can be sure it's a wireless
@@ -78,14 +82,23 @@ static net_type_t iface_type(const char *ifname) {
     struct ifreq ifr;
     struct ieee80211_bssid bssid;
     struct ieee80211_nwid nwid;
+#elif defined(__DragonFly__)
+    struct ieee80211req ifr;
+#endif
+#if defined(__OpenBSD__) || defined(__DragonFly__)
     struct ifmediareq ifmr;
-
-    int s, ibssid, inwid;
-
+    int s;
+#endif
+#if defined(__OpenBSD__)
+    int ibssid, inwid;
+#endif
+#if defined(__OpenBSD__) || defined(__DragonFly__)
     if ((s = socket(AF_INET, SOCK_DGRAM, 0)) == -1)
         return NET_TYPE_OTHER;
 
     memset(&ifr, 0, sizeof(ifr));
+#endif
+#if defined(__OpenBSD__)
     ifr.ifr_data = (caddr_t)&nwid;
     (void)strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
     inwid = ioctl(s, SIOCG80211NWID, (caddr_t)&ifr);
@@ -98,7 +111,15 @@ static net_type_t iface_type(const char *ifname) {
         close(s);
         return NET_TYPE_WIRELESS;
     }
-
+#elif defined(__DragonFly__)
+    (void)strlcpy(ifr.i_name, ifname, sizeof(ifr.i_name));
+    ifr.i_type = IEEE80211_IOC_NUMSSIDS;
+    if (ioctl(s, SIOCG80211, &ifr) == 0) {
+        close(s);
+        return NET_TYPE_WIRELESS;
+    }
+#endif
+#if defined(__OpenBSD__) || defined(__DragonFly__)
     (void)memset(&ifmr, 0, sizeof(ifmr));
     (void)strlcpy(ifmr.ifm_name, ifname, sizeof(ifmr.ifm_name));
 

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -38,6 +38,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <ifaddrs.h>
+#include <stdlib.h>
 #include <net/if.h>
 #include <net/if_media.h>
 #include <netproto/802_11/ieee80211.h>


### PR DESCRIPTION
Currently there is no interface type detection in DragonFly which, on the default config, shows "down" for both wireless and ethernet devices.

**BEFORE:**

    no IPv6 | 31.9 GiB | W: down | E: down | No batteryNo battery | 1.05 |  | 2018-07-15 21:50:10

**AFTER:**

    no IPv6 | 31.9 GiB | W: down | E: 192.168.1.39 (1000baseT) | No batteryNo battery | 1.25 |  | 2018-07-15 21:50:45

I've also tried this patch on OpenBSD 6.1 but only with a Ethernet interface, it would be needed to be tested with a WLAN interface as well but I don't have any:

    # ./i3status -c i3status.conf 
    i3status: trying to auto-detect output_format setting
    i3status: auto-detected "term"
    i3status: Memory status information is not supported on this system
    no IPv6 | 636.7 MiB | W: down | E: 192.168.4.163 (1000baseT) | No battery | 1.23 |  | 2018-07-15 21:52:49
    # uname -a
    OpenBSD openbsd6.sector.int 6.1 GENERIC.MP#20 amd64

