### PR TITLE
Fix for issue 300: Correctly print usage for cpu 10

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -163,7 +163,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const 
             }
             int padding = 1;
             int step = 10;
-            while (step < number) {
+            while (step <= number) {
                 step *= 10;
                 padding++;
             }

--- a/testcases/022-cpu-usage-tenth-cpu/cleanup.pl
+++ b/testcases/022-cpu-usage-tenth-cpu/cleanup.pl
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl
+
+use v5.10;
+use strict;
+use warnings;
+
+if ($#ARGV != 0 || ! -d $ARGV[0]) {
+    say "Error with cleanup script: argument not provided or not a directory";
+    exit 1;
+}
+
+my $output_file = "$ARGV[0]/stat";
+if (-f $output_file) {
+    unlink $output_file;
+}

--- a/testcases/022-cpu-usage-tenth-cpu/expected_output.pl
+++ b/testcases/022-cpu-usage-tenth-cpu/expected_output.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+
+use v5.10;
+use strict;
+use warnings;
+
+chomp(my $cpu_count = `grep -c -P '^processor\\s+:' /proc/cpuinfo`);
+if ($cpu_count < 10) {
+    print "all: 00% CPU_0: 00% CPU_10: \n";
+} else {
+    print "all: 00% CPU_0: 00% CPU_10: 00%\n";
+}

--- a/testcases/022-cpu-usage-tenth-cpu/i3status.conf
+++ b/testcases/022-cpu-usage-tenth-cpu/i3status.conf
@@ -1,0 +1,10 @@
+general {
+        output_format = "none"
+}
+
+order += "cpu_usage"
+
+cpu_usage {
+    format = "all: %usage CPU_0: %cpu0 CPU_10: %cpu10"
+    path = "testcases/022-cpu-usage-tenth-cpu/stat"
+}

--- a/testcases/022-cpu-usage-tenth-cpu/setup.pl
+++ b/testcases/022-cpu-usage-tenth-cpu/setup.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+use v5.10;
+use strict;
+use warnings;
+
+if ($#ARGV != 0 || ! -d $ARGV[0]) {
+    say "Error with setup script: argument not provided or not a directory";
+    exit 1;
+}
+
+chomp(my $cpu_count = `grep -c -P '^processor\\s+:' /proc/cpuinfo`);
+my $output_file = "$ARGV[0]/stat";
+open(my $fh, '>', $output_file) or die "Could not open file '$output_file' $!";
+print $fh "cpu  0 0 0 0 0 0 0 0 0 0\n";
+for (my $i = 0; $i < $cpu_count; $i++) {
+    print $fh "cpu$i 0 0 0 0 0 0 0 0 0 0\n";
+}
+close $fh;


### PR DESCRIPTION
In cpu_print_usage.c, the step factor used to figure out how many extra characters to skip over when parsing through '%cpuN' directive is 10.

With a < comparison and a cpu directive of "%cpu10", the comparison fails, nothing is added to padding, only one character gets skipped, and the 0 character from "%cpu10" ends up being copied to the output buffer. This occurs only for CPU 10.

This PR changes that comparison to <= and adds a test for the issue. I've confirmed the test succeeds on hosts with more than, and less than, 10 cpus. With less than 10 cpus the test is set up to always succeed, in line with what the other cpu usage tests appear to be doing around having one or more than one cpu.

