### PR TITLE
man: fix typo for max_threshold in load

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -489,7 +489,7 @@ format_above_threshold.
 
 *Example format*: +%1min %5min %15min+
 
-*Example max_threshold*: +"0,1"+
+*Example max_threshold*: +"0.1"+
 
 *Example format_above_threshold*: +Warning: %1min %5min %15min+
 


### PR DESCRIPTION
Floating values use a dot (not a comma).

Fixes:

	invalid floating point value for option 'max_threshold'