### PR TITLE
print_cpu_usage: fix invalid %cpu placeholder output

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -151,7 +151,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const 
         }
 #if defined(LINUX)
         else if (BEGINS_WITH(walk + 1, "cpu")) {
-            int number = 0;
+            int number = -1;
             sscanf(walk + 1, "cpu%d", &number);
             if (number < 0 || number >= cpu_count) {
                 fprintf(stderr, "provided CPU number '%d' above detected number of CPU %d\n", number, cpu_count);


### PR DESCRIPTION
Currently, the module cpu_usage prints %cpu0 information for the invalid
%cpu placeholder (i.e. the cpu number is missing).

Consider the following configuration.

	order += "cpu_usage"

	cpu_usage {
		format = "cpu0=%cpu0 cpu1=%cpu1 cpu=%cpu"
		# missing cpu number -------------------^
	}

The configuration above produces the output below.

	$ i3status -c config
	i3status: trying to auto-detect output_format setting
	i3status: auto-detected "term"
	cpu0=-2% cpu1=-49% cpu=-2%
	cpu0=06% cpu1=02% cpu=06%
	cpu0=05% cpu1=06% cpu=05%
	...

The module prints %cpu0 at the third placeholder where it should report
an error.

This commit fixes this behavior by initializing `number' to -1. If the
cpu is missing in %cpu placeholder, the sscanf function does not set
`number'. Because `number' is -1 (lower to 0), an error is reported and
the placeholder is skipped.

	$ i3status -c ./config
	i3status: trying to auto-detect output_format setting
	i3status: auto-detected "term"
	provided CPU number '-1' above detected number of CPU 4
	cpu0= cpu1=-48% cpu=
	provided CPU number '-1' above detected number of CPU 4
	cpu0= cpu1=11% cpu=
	provided CPU number '-1' above detected number of CPU 4
	cpu0= cpu1=03% cpu=
	...