### PR TITLE
Fix error messages

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -666,7 +666,7 @@ int main(int argc, char *argv[]) {
 
     while (1) {
         if (exit_upon_signal) {
-            fprintf(stderr, "Exiting due to signal.\n");
+            fprintf(stderr, "i3status: exiting due to signal.\n");
             exit(1);
         }
         struct timeval tv;

--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -165,8 +165,10 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const 
         else if (BEGINS_WITH(walk + 1, "cpu")) {
             int number = -1;
             sscanf(walk + 1, "cpu%d", &number);
-            if (number < 0 || number >= cpu_count) {
-                fprintf(stderr, "provided CPU number '%d' above detected number of CPU %d\n", number, cpu_count);
+            if (number == -1) {
+                fprintf(stderr, "i3status: provided CPU number cannot be parsed\n");
+            } else if (number >= cpu_count) {
+                fprintf(stderr, "i3status: provided CPU number '%d' above detected number of CPU %d\n", number, cpu_count);
             } else {
                 int cpu_diff_idle = curr_cpus[number].idle - prev_cpus[number].idle;
                 int cpu_diff_total = curr_cpus[number].total - prev_cpus[number].total;


### PR DESCRIPTION
I noticed both these error messages weren't prefixed by `i3status: `. I moved CPU number parsing error to two distinct messages for clarity's sake.