### PR TITLE
Add timezone switch

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -399,6 +399,7 @@ int main(int argc, char *argv[]) {
         CFG_STR("timezone", "", CFGF_NONE),
         CFG_STR("locale", "", CFGF_NONE),
         CFG_STR("format_time", NULL, CFGF_NONE),
+        CFG_BOOL("only_when_tz_different", false, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_MIN_WIDTH_OPT,
         CFG_CUSTOM_SEPARATOR_OPT,
@@ -749,13 +750,13 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC("time") {
                 SEC_OPEN_MAP("time");
-                print_time(json_gen, buffer, NULL, cfg_getstr(sec, "format"), NULL, NULL, NULL, tv.tv_sec);
+                print_time(json_gen, buffer, NULL, cfg_getstr(sec, "format"), NULL, NULL, NULL, false, tv.tv_sec);
                 SEC_CLOSE_MAP;
             }
 
             CASE_SEC_TITLE("tztime") {
                 SEC_OPEN_MAP("tztime");
-                print_time(json_gen, buffer, title, cfg_getstr(sec, "format"), cfg_getstr(sec, "timezone"), cfg_getstr(sec, "locale"), cfg_getstr(sec, "format_time"), tv.tv_sec);
+                print_time(json_gen, buffer, title, cfg_getstr(sec, "format"), cfg_getstr(sec, "timezone"), cfg_getstr(sec, "locale"), cfg_getstr(sec, "format_time"), cfg_getbool(sec, "only_when_tz_different"), tv.tv_sec);
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -214,7 +214,7 @@ const char *first_eth_interface(const net_type_t type);
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
 void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_below_threshold, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);
 void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
-void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, time_t t);
+void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, bool only_when_tz_different, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
 const char *get_ip_addr(const char *interface, int family);
 void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down, const char *quality_min_lenght);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -97,6 +97,7 @@ path_exists VPN {
 
 tztime local {
         format = "%Y-%m-%d %H:%M:%S"
+        only_when_tz_different = true
 }
 
 tztime berlin {
@@ -514,6 +515,8 @@ Files below that path make for valid timezone strings, e.g. for
 +/usr/share/zoneinfo/Europe/Berlin+ you can set timezone to +Europe/Berlin+
 in the +tztime+ module.
 To override the locale settings of your environment, set the +locale+ option.
+To display time only when the timezone is different from local timezone, set
++only_when_tz_different+ to true.
 
 *Example order*: +tztime berlin+
 
@@ -533,6 +536,7 @@ tztime berlin {
 	format = "<span foreground='#ffffff'>time:</span> %time"
 	format_time = "%H:%M %Z"
 	timezone = "Europe/Berlin"
+	only_when_tz_different = false
 }
 -------------------------------------------------------------
 


### PR DESCRIPTION
This adds the feature requested by #303.

The only drawback I see, is that when nothing should be displayed because the timezone is the same, then a [separator is anyway added](https://github.com/i3/i3status/blob/master/i3status.c#L681-L682).

I think we could fix that in a separate PR.