### PR TITLE
Outputs the stdout of the specified shell command

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -491,6 +491,15 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t exec_opts[] = {
+        CFG_STR("command", "echo -n no_command", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_CUSTOM_SEPARATOR_OPT,
+        CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
@@ -509,6 +518,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("load", load_opts, CFGF_NONE),
         CFG_SEC("memory", memory_opts, CFGF_NONE),
         CFG_SEC("cpu_usage", usage_opts, CFGF_NONE),
+        CFG_SEC("exec", exec_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_END()};
 
     char *configfile = NULL;
@@ -785,6 +795,12 @@ int main(int argc, char *argv[]) {
             CASE_SEC("cpu_usage") {
                 SEC_OPEN_MAP("cpu_usage");
                 print_cpu_usage(json_gen, buffer, cfg_getstr(sec, "format"), cfg_getstr(sec, "format_above_threshold"), cfg_getstr(sec, "format_above_degraded_threshold"), cfg_getstr(sec, "path"), cfg_getfloat(sec, "max_threshold"), cfg_getfloat(sec, "degraded_threshold"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("exec") {
+                SEC_OPEN_MAP("exec");
+                print_exec(json_gen, buffer, cfg_getstr(sec, "command"));
                 SEC_CLOSE_MAP;
             }
         }

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -213,6 +213,7 @@ const char *first_eth_interface(const net_type_t type);
 
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
 void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_below_threshold, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);
+void print_exec(yajl_gen json_gen, char *buffer, const char *command);
 void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, bool hide_if_equals_localtime, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -611,6 +611,17 @@ volume master {
 }
 -------------------------------------------------------------
 
+=== Execute
+
+Outputs the stdout of the specified shell command.
+
+*Example configuration*:
+-------------------------------------------------------------
+exec uname {
+	command = "uname -smor"
+}
+-------------------------------------------------------------
+
 == Universal module options
 
 When using the i3bar output format, there are a few additional options that

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -621,6 +621,14 @@ exec uname {
 	command = "uname -smor"
 }
 -------------------------------------------------------------
+*Example configuration (Average CPU frequency)*:
+-------------------------------------------------------------
+exec avg_cpuMHz {
+	command = "/bin/sh -c 'cat /proc/cpuinfo|grep \"cpu MHz\"|\
+	sed \"s/.*: //\"|\
+	awk \"BEGIN{s=0}{s+=\\$1}END{printf(\\\"%.1fMHz\\\", s/NR)}\"'"
+}
+-------------------------------------------------------------
 
 == Universal module options
 

--- a/src/print_exec.c
+++ b/src/print_exec.c
@@ -9,23 +9,21 @@
 
 #include "i3status.h"
 
-
-
 void print_exec(yajl_gen json_gen, char *buffer, const char *command) {
     char *outwalk = buffer;
 
     FILE *fproc = popen(command, "r");
     char buf[256];
-    while(!feof(fproc)){
+    while (!feof(fproc)) {
         size_t rd = fread(buf, 1, 255, fproc);
-        snprintf(outwalk, rd+1, "%s", buf);
-        outwalk+=rd;
+        snprintf(outwalk, rd + 1, "%s", buf);
+        outwalk += rd;
     }
     pclose(fproc);
 
-    while(*(outwalk-1)=='\n') outwalk--;
+    while (*(outwalk - 1) == '\n')
+        outwalk--;
 
     *outwalk = '\0';
     OUTPUT_FULL_TEXT(buffer);
 }
-

--- a/src/print_exec.c
+++ b/src/print_exec.c
@@ -1,0 +1,31 @@
+// vim:ts=4:sw=4:expandtab
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdint.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+
+#include "i3status.h"
+
+
+
+void print_exec(yajl_gen json_gen, char *buffer, const char *command) {
+    char *outwalk = buffer;
+
+    FILE *fproc = popen(command, "r");
+    char buf[256];
+    while(!feof(fproc)){
+        size_t rd = fread(buf, 1, 255, fproc);
+        snprintf(outwalk, rd+1, "%s", buf);
+        outwalk+=rd;
+    }
+    pclose(fproc);
+
+    while(*(outwalk-1)=='\n') outwalk--;
+
+    *outwalk = '\0';
+    OUTPUT_FULL_TEXT(buffer);
+}
+


### PR DESCRIPTION
Added a "exec" module that can invoke a shell-command/user-scripts and read its stdout.
Config format:
```
exec <name> {
    command = "<shell-command>"
}
```
Example:
```
exec uname {
    command = "uname -smor"
}
```
Result: `{"name":"exec","markup":"none","full_text":"Linux 4.9.0-5-amd64 x86_64 GNU/Linux"}`
Example2 (Average CPU frequency):
```
exec avg_cpuMHz {
    command = "/bin/sh -c 'cat /proc/cpuinfo|grep \"cpu MHz\"|\
    sed \"s/.*: //\"|\
    awk \"BEGIN{s=0}{s+=\\$1}END{printf(\\\"%.1fMHz\\\", s/NR)}\"'"
}
```
Result:` {"name":"exec","markup":"none","full_text":"908.9MHz"}`
