### PR TITLE
Implement %devicename specifier for volume module

### DIFF
--- a/include/i3status.h
+++ b/include/i3status.h
@@ -36,6 +36,7 @@ extern char *pct_mark;
 #define COMPOSE_VOLUME_MUTE(vol, mute) ((vol) | ((mute) ? (1 << 30) : 0))
 #define DECOMPOSE_VOLUME(cvol) ((cvol) & ~(1 << 30))
 #define DECOMPOSE_MUTED(cvol) (((cvol) & (1 << 30)) != 0)
+#define MAX_SINK_DESCRIPTION_LEN (128) /* arbitrary */
 
 #if defined(LINUX)
 
@@ -228,6 +229,7 @@ void print_memory(yajl_gen json_gen, char *buffer, const char *format, const cha
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
 bool process_runs(const char *path);
 int volume_pulseaudio(uint32_t sink_idx, const char *sink_name);
+bool description_pulseaudio(uint32_t sink_idx, const char *sink_name, char buffer[MAX_SINK_DESCRIPTION_LEN]);
 bool pulse_initialize(void);
 
 /* socket file descriptor for general purposes */

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -581,9 +581,9 @@ to "default", PulseAudio will be tried if detected and will fallback to ALSA
 
 *Example order*: +volume master+
 
-*Example format*: +♪: %volume+
+*Example format*: +♪ (%devicename): %volume+
 
-*Example format_muted*: +♪: 0%%+
+*Example format_muted*: +♪ (%devicename): 0%%+
 
 *Example configuration*:
 -------------------------------------------------------------


### PR DESCRIPTION
This commit implements the %devicename specifier for the volume module
for both PulseAudio and ALSA. This way, i3status will be able to display
the specific device that corresponds to the volume indicator.

Note that this is not implemented for the OSS API but is left in a state
where someone can pick it up for the future.

---

I implemented this because I have a pair of Bluetooth headphones that may not be connected. I'd like to check where the default sink is set to before blaring music so that I don't potentially annoy people in the same room.

Also, I tried to implement the OSS API portion but after mucking through the header files and the docuentation, I didn't want to implement something that may have had incorrect behaviour since I don't have a BSD system to test on.