### PR TITLE
Reformat code using clang-format

### DIFF
--- a/src/print_load.c
+++ b/src/print_load.c
@@ -8,7 +8,7 @@
 
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const char *format_above_threshold, const float max_threshold) {
     char *outwalk = buffer;
-/* Get load */
+    /* Get load */
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(linux) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(sun) || defined(__DragonFly__)
     double loadavg[3];

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -160,11 +160,11 @@ static int gwi_sta_cb(struct nl_msg *msg, void *data) {
     struct nlattr *sinfo[NL80211_STA_INFO_MAX + 1];
     struct nlattr *rinfo[NL80211_RATE_INFO_MAX + 1];
     static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
-            [NL80211_STA_INFO_RX_BITRATE] = {.type = NLA_NESTED},
+        [NL80211_STA_INFO_RX_BITRATE] = {.type = NLA_NESTED},
     };
 
     static struct nla_policy rate_policy[NL80211_RATE_INFO_MAX + 1] = {
-            [NL80211_RATE_INFO_BITRATE] = {.type = NLA_U16},
+        [NL80211_RATE_INFO_BITRATE] = {.type = NLA_U16},
     };
 
     if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL) < 0)
@@ -198,12 +198,12 @@ static int gwi_scan_cb(struct nl_msg *msg, void *data) {
     struct nlattr *tb[NL80211_ATTR_MAX + 1];
     struct nlattr *bss[NL80211_BSS_MAX + 1];
     struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {
-            [NL80211_BSS_FREQUENCY] = {.type = NLA_U32},
-            [NL80211_BSS_BSSID] = {.type = NLA_UNSPEC},
-            [NL80211_BSS_INFORMATION_ELEMENTS] = {.type = NLA_UNSPEC},
-            [NL80211_BSS_SIGNAL_MBM] = {.type = NLA_U32},
-            [NL80211_BSS_SIGNAL_UNSPEC] = {.type = NLA_U8},
-            [NL80211_BSS_STATUS] = {.type = NLA_U32},
+        [NL80211_BSS_FREQUENCY] = {.type = NLA_U32},
+        [NL80211_BSS_BSSID] = {.type = NLA_UNSPEC},
+        [NL80211_BSS_INFORMATION_ELEMENTS] = {.type = NLA_UNSPEC},
+        [NL80211_BSS_SIGNAL_MBM] = {.type = NLA_U32},
+        [NL80211_BSS_SIGNAL_UNSPEC] = {.type = NLA_U8},
+        [NL80211_BSS_STATUS] = {.type = NLA_U32},
     };
 
     if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL) < 0)


### PR DESCRIPTION
According to the contribution guidelines, code should be formatted with
clang-format before submitting a pull request. This change cleans up
code that previously did not conform so that future changes
pull-requests running clang-format will not affect unrelated files.