### PR TITLE
ipv6: add support for %iface

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -235,9 +235,10 @@ disk "/" {
 === IPv6
 
 This module gets the IPv6 address used for outgoing connections (that is, the
-best available public IPv6 address on your computer).
+best available public IPv6 address on your computer) and the interface it is
+assigned to.
 
-*Example format_up*: +%ip+
+*Example format_up*: +%iface: %ip+
 
 *Example format_down*: +no IPv6+
 


### PR DESCRIPTION
This follows the discussions in #205.

One problem is that in order to determine the IPv6's interface, we need to use `getifaddrs(3)` and walk through its linked list. We could return a cached value when we query the same IPv6 address twice in a row but that's not perfect, what do you think?