### PR TITLE
Fix non Linux build for #309

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -1,6 +1,8 @@
 // vim:ts=4:sw=4:expandtab
 #include <config.h>
+#if defined(__linux__)
 #include <sys/sysinfo.h>
+#endif
 #include <stdlib.h>
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
This wasn't wrapped correctly in #309 and broke build on non Linux architecture (ex: MacOS).