### PR TITLE
fix ethernet speed display for 100 Gbit/s cards

### DIFF
--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -43,7 +43,7 @@ static int print_eth_speed(char *outwalk, const char *interface) {
     ifr.ifr_data = (caddr_t)&ecmd;
     (void)strcpy(ifr.ifr_name, interface);
     if (ioctl(general_socket, SIOCETHTOOL, &ifr) == 0) {
-        ethspeed = (ecmd.speed == USHRT_MAX ? 0 : ecmd.speed);
+        ethspeed = (ecmd.speed == USHRT_MAX ? 0 : ethtool_cmd_speed(&ecmd));
         return sprintf(outwalk, "%d Mbit/s", ethspeed);
     } else
         return sprintf(outwalk, "?");


### PR DESCRIPTION
Before this fix, i3status would display 34464 Mbit/s instead of 100000 Mbit/s,
because it was only looking at ecmd.speed, ignoring ecmd.speed_hi.