### PR TITLE
default config: move disk info out of network info

### DIFF
--- a/i3status.conf
+++ b/i3status.conf
@@ -12,10 +12,10 @@ general {
 }
 
 order += "ipv6"
-order += "disk /"
 order += "wireless _first_"
 order += "ethernet _first_"
 order += "battery all"
+order += "disk /"
 order += "load"
 order += "memory"
 order += "tztime local"
@@ -34,8 +34,8 @@ battery all {
         format = "%status %percentage %remaining"
 }
 
-tztime local {
-        format = "%Y-%m-%d %H:%M:%S"
+disk "/" {
+        format = "%avail"
 }
 
 load {
@@ -48,6 +48,6 @@ memory {
         format_degraded = "MEMORY < %available"
 }
 
-disk "/" {
-        format = "%avail"
+tztime local {
+        format = "%Y-%m-%d %H:%M:%S"
 }


### PR DESCRIPTION
By default, disk info is found in a strange place in between ipv6 and wireless information. This commit puts it in between other performance meters. Settings in the file are also now sorted according to their places in the order.