### PR TITLE
Increase buffer size for print_cpu_usage

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -76,7 +76,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const 
     }
 
     memcpy(curr_cpus, prev_cpus, cpu_count * sizeof(struct cpu_usage));
-    char buf[4096];
+    char buf[16384];
     curr_cpu_count = get_nprocs();
     if (!slurp(path, buf, sizeof(buf)))
         goto error;


### PR DESCRIPTION
My computer has 72 cores listed in /proc/stat, and after a few weeks of uptime, the numbers get big enough that it doesn't fit in 4096 bytes.