### PR TITLE
print_cpu_usage: double buffer size

### DIFF
--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -76,7 +76,7 @@ void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const 
     }
 
     memcpy(curr_cpus, prev_cpus, cpu_count * sizeof(struct cpu_usage));
-    char buf[4096];
+    char buf[8192];
     curr_cpu_count = get_nprocs();
     if (!slurp(path, buf, sizeof(buf)))
         goto error;


### PR DESCRIPTION
On systems with many cores, the current 4096 bytes are not sufficient to hold the contents of the /proc file.