### PR TITLE
print_file_contents: allocate enough to include \0

### DIFF
--- a/src/print_file_contents.c
+++ b/src/print_file_contents.c
@@ -23,7 +23,7 @@ static void *scalloc(size_t size) {
 void print_file_contents(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_bad, const int max_chars) {
     const char *walk = format;
     char *outwalk = buffer;
-    char *buf = scalloc(max_chars * sizeof(char));
+    char *buf = scalloc(max_chars * sizeof(char) + 1);
 
     int n = -1;
     int fd = open(path, O_RDONLY);

--- a/testcases/025-file-contents/expected_output.txt
+++ b/testcases/025-file-contents/expected_output.txt
@@ -1,1 +1,1 @@
-contents | NONEXISTANT - 2: No such file or directory
+contents | con | NONEXISTANT - 2: No such file or directory

--- a/testcases/025-file-contents/i3status.conf
+++ b/testcases/025-file-contents/i3status.conf
@@ -3,10 +3,16 @@ general {
 }
 
 order += "read_file EXISTING"
+order += "read_file TRUNCATED"
 order += "read_file NONEXISTANT"
 
 read_file EXISTING {
         path = "testcases/025-file-contents/short.txt"
+}
+
+read_file TRUNCATED {
+        path = "testcases/025-file-contents/short.txt"
+        max_characters = 3
 }
 
 read_file NONEXISTANT {


### PR DESCRIPTION
related to #331
Previously, if max_chars was read, the null byte would be written
past the end of buf.