### PR TITLE
wireless: render frequency in megahertz

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -579,7 +579,7 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
 
         } else if (BEGINS_WITH(walk + 1, "frequency")) {
             if (info.flags & WIRELESS_INFO_FLAG_HAS_FREQUENCY)
-                outwalk += sprintf(outwalk, "%1.1f GHz", info.frequency / 1e9);
+                outwalk += sprintf(outwalk, "%1.0f MHz", info.frequency / 1e6);
             else
                 *(outwalk++) = '?';
             walk += strlen("frequency");


### PR DESCRIPTION
Rendering the exact frequency in MHz (for example "2472 MHz") rather than rounded to "2.5 GHz" allows the user to see exactly which wireless channel they are operating on.

In a multi-AP setup this also allows one to quickly see if roaming works correctly, and check which AP one is connected with.

For me, this increases the usefulness of the frequency info dramatically, I hope you will also find it useful.