### PR TITLE
Fix headers meant for OpenBSD, but snuck in for FreeBSD

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -20,8 +20,6 @@
 #include <dev/acpica/acpiio.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
-#include <sys/sysctl.h>
-#include <sys/sensors.h>
 #endif
 
 #if defined(__DragonFly__)
@@ -33,6 +31,7 @@
 #include <sys/fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
+#include <sys/sysctl.h>
 #include <sys/sensors.h>
 #endif
 


### PR DESCRIPTION
I accidentally added the headers to the FreeBSD block when merging the patch to git for submission in #351 