### PR TITLE
add 'Text' module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ i3status_SOURCES = \
 	src/print_volume.c \
 	src/print_wireless_info.c \
 	src/print_file_contents.c \
+	src/print_text.c \
 	src/process_runs.c \
 	src/pulse.c
 

--- a/i3status.c
+++ b/i3status.c
@@ -503,6 +503,15 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t text_opts[] = {
+        CFG_STR("text", NULL, CFGF_NONE),
+        CFG_STR("color", NULL, CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_CUSTOM_SEPARATOR_OPT,
+        CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
@@ -522,6 +531,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("memory", memory_opts, CFGF_NONE),
         CFG_SEC("cpu_usage", usage_opts, CFGF_NONE),
         CFG_SEC("read_file", read_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("text", text_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_END()};
 
     char *configfile = NULL;
@@ -804,6 +814,19 @@ int main(int argc, char *argv[]) {
             CASE_SEC_TITLE("read_file") {
                 SEC_OPEN_MAP("read_file");
                 print_file_contents(json_gen, buffer, title, cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_bad"), cfg_getint(sec, "max_characters"));
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("text") {
+                SEC_OPEN_MAP("text");
+                const char *colorstr = NULL;
+                if (cfg_getbool(cfg_general, "colors")) {
+                    colorstr = cfg_getstr(sec, "color");
+                    if (strlen(colorstr) < 1 ||
+                       (colorstr[0] == '#' && !valid_color(colorstr)))
+                        die("Bad color format in text module");
+                }
+                print_text(json_gen, buffer, cfg_getstr(sec, "text"), colorstr);
                 SEC_CLOSE_MAP;
             }
         }

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -147,10 +147,14 @@ extern char *pct_mark;
     do {                                                                                    \
         if (cfg_getbool(cfg_general, "colors")) {                                           \
             const char *_val = NULL;                                                        \
-            if (cfg_section)                                                                \
-                _val = cfg_getstr(cfg_section, colorstr);                                   \
-            if (!_val)                                                                      \
-                _val = cfg_getstr(cfg_general, colorstr);                                   \
+            if (colorstr[0] == '#')                                                         \
+                _val = colorstr;                                                            \
+            else {                                                                          \
+                if (cfg_section)                                                            \
+                    _val = cfg_getstr(cfg_section, colorstr);                               \
+                if (!_val)                                                                  \
+                    _val = cfg_getstr(cfg_general, colorstr);                               \
+            }                                                                               \
             if (output_format == O_I3BAR) {                                                 \
                 yajl_gen_string(json_gen, (const unsigned char *)"color", strlen("color")); \
                 yajl_gen_string(json_gen, (const unsigned char *)_val, strlen(_val));       \
@@ -232,6 +236,7 @@ int volume_pulseaudio(uint32_t sink_idx, const char *sink_name);
 bool description_pulseaudio(uint32_t sink_idx, const char *sink_name, char buffer[MAX_SINK_DESCRIPTION_LEN]);
 bool pulse_initialize(void);
 void print_file_contents(yajl_gen json_gen, char *buffer, const char *title, const char *path, const char *format, const char *format_bad, const int max_chars);
+void print_text(yajl_gen json_gen, char *buffer, const char *text, const char *colorstr);
 
 /* socket file descriptor for general purposes */
 extern int general_socket;

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -635,6 +635,22 @@ If the file is not found "no file" will be printed, if the file can't be read
 
 *Example Max_characters*: 255
 
+=== Text
+
+Outputs arbitrary colored text blocks via +text+ and +color+ options. Intended
+for use as string literals and placeholders for post-processing.
+
+*Example configuration*:
+-------------------------------------------------------------
+text name {
+	text = "SpongeBobSquarePants"
+	color = "#555555"
+}
+text net_speed {
+	text = "_NET_SPEED_CONSOLIDATED_"
+}
+-------------------------------------------------------------
+
 == Universal module options
 
 When using the i3bar output format, there are a few additional options that

--- a/src/output.c
+++ b/src/output.c
@@ -22,19 +22,21 @@ char *color(const char *colorstr) {
         colorbuf[0] = '\0';
         return colorbuf;
     }
+
+    const char *color_ = colorstr[0] == '#' ? colorstr : cfg_getstr(cfg_general, colorstr);
+
     if (output_format == O_DZEN2)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "^fg(%s)", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "^fg(%s)", color_);
     else if (output_format == O_XMOBAR)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "<fc=%s>", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "<fc=%s>", color_);
     else if (output_format == O_LEMONBAR)
-        (void)snprintf(colorbuf, sizeof(colorbuf), "%%{F%s}", cfg_getstr(cfg_general, colorstr));
+        (void)snprintf(colorbuf, sizeof(colorbuf), "%%{F%s}", color_);
     else if (output_format == O_TERM) {
         /* The escape-sequence for color is <CSI><col>;1m (bright/bold
          * output), where col is a 3-bit rgb-value with b in the
          * least-significant bit. We round the given color to the
          * nearist 3-bit-depth color and output the escape-sequence */
-        char *str = cfg_getstr(cfg_general, colorstr);
-        int col = strtol(str + 1, NULL, 16);
+        int col = strtol(color_ + 1, NULL, 16);
         int r = (col & (0xFF << 0)) / 0x80;
         int g = (col & (0xFF << 8)) / 0x8000;
         int b = (col & (0xFF << 16)) / 0x800000;


### PR DESCRIPTION
-facilitates bespoke literal string blocks of arbitrary colour

..and as per the man page entry:

Intended for use as string literals and placeholders for post-processing.

...

Hardly an Earth shattering addition, but this eased my requirements whilst setting up the net speed (contrib) hack. Primary, I refused to abuse / pollute other blocks to get the job done (e.g. placeholders in other format lines ..which adds unwanted chaining). For literals, I wanted arbitrary colours without the indirect (and limiting) configuration of a named colour.

Thanks for the tool.

pic:
![2019Jul09 i3status text](https://user-images.githubusercontent.com/2130062/60878204-32299e00-a237-11e9-91da-80b68d052732.png)
