### PR TITLE
On NetBSD, include sys/socket.h for AF_INET{,6}.

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -61,6 +61,7 @@
 
 #ifdef __NetBSD__
 #include <sys/types.h>
+#include <sys/socket.h>
 #include <net80211/ieee80211.h>
 #define IW_ESSID_MAX_SIZE IEEE80211_NWID_LEN
 #endif


### PR DESCRIPTION
Fixes https://github.com/i3/i3status/issues/358