### PR TITLE
Improve the netspeed wrapper

### DIFF
--- a/contrib/net-speed.sh
+++ b/contrib/net-speed.sh
@@ -50,25 +50,22 @@ readable() {
 
 update_rate() {
   local time=$(date +%s)
-  local rx=0 tx=0 tmp_rx tmp_tx
-
-  for iface in $ifaces; do
-    read tmp_rx < "/sys/class/net/${iface}/statistics/rx_bytes"
-    read tmp_tx < "/sys/class/net/${iface}/statistics/tx_bytes"
-    rx=$(( rx + tmp_rx ))
-    tx=$(( tx + tmp_tx ))
-  done
-
   local interval=$(( $time - $last_time ))
   if [ $interval -gt 0 ]; then
-    rate="$(readable $(( (rx - last_rx) / interval )))↓ $(readable $(( (tx - last_tx) / interval )))↑"
-  else
-    rate=""
-  fi
+    local rx=0 tx=0 tmp_rx tmp_tx
 
-  last_time=$time
-  last_rx=$rx
-  last_tx=$tx
+    for iface in $ifaces; do
+      read tmp_rx < "/sys/class/net/${iface}/statistics/rx_bytes"
+      read tmp_tx < "/sys/class/net/${iface}/statistics/tx_bytes"
+      rx=$(( rx + tmp_rx ))
+      tx=$(( tx + tmp_tx ))
+    done
+
+    rate="$(readable $(( (rx - last_rx) / interval )))↓ $(readable $(( (tx - last_tx) / interval )))↑"
+    last_time=$time
+    last_rx=$rx
+    last_tx=$tx
+  fi
 }
 
 i3status | (read line && echo "$line" && read line && echo "$line" && read line && echo "$line" && update_rate && while :

--- a/contrib/net-speed.sh
+++ b/contrib/net-speed.sh
@@ -35,7 +35,7 @@ readable() {
   local bytes=$1
   local kib=$(( bytes >> 10 ))
   if [ $kib -lt 0 ]; then
-    echo "? K"
+    echo "? k"
   elif [ $kib -gt 1024 ]; then
     local mib_int=$(( kib >> 10 ))
     local mib_dec=$(( kib % 1024 * 976 / 10000 ))
@@ -44,7 +44,7 @@ readable() {
     fi
     echo "${mib_int}.${mib_dec} M"
   else
-    echo "${kib} K"
+    echo "${kib} k"
   fi
 }
 


### PR DESCRIPTION
Two small improvements for the netspeed wrapper:

1. Use "k" instead of "K" as not only the correct unit but more easily distinguishable from "M".
2. Fix the disappearance of the rate when the bar updated too quickly