### PR TITLE
configure.ac: exclude build without running git

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,15 +144,12 @@ AX_SANITIZERS(, [$default_sanitizers], [AC_DEFINE([I3STATUS_ASAN_ENABLED], [], [
 
 AC_OUTPUT
 
-in_git_worktree=`git rev-parse --is-inside-work-tree 2>/dev/null`
-if [ "$in_git_worktree" = "true" ]; then
-	git_dir=`git rev-parse --git-dir 2>/dev/null`
-	srcdir=`dirname "$git_dir"`
-	exclude_dir=`pwd | sed "s,^$srcdir,,g"`
-	if ! grep -q "^$exclude_dir" "$git_dir/info/exclude"; then
-		echo "$exclude_dir" >> "$git_dir/info/exclude"
-	fi
-fi
+AS_IF([test -d ${srcdir}/.git], [
+	srcdir_abs=`readlink -f "$srcdir"`
+	exclude_dir=`pwd | sed "s,^$srcdir_abs/*,,g"`
+	AS_IF([! grep -q "^$exclude_dir" "${srcdir}/.git/info/exclude"],
+	      [echo "$exclude_dir" >> "${srcdir}/.git/info/exclude"])])
+
 
 echo \
 "--------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, `configure.ac` runs `git rev-parse` inconditionally in order to remove the build dir automatically from git tracking. But, it may travel outside of the build directory, finding a gitdir away from the srcdir, for eg. when distributing an archive, thus modifing it. When using a sandbox to build it, it catches that but also disallow to run it safely.

This PR avoid reading the gitdir before it's checked for existence thus avoiding this issue.