### PR TITLE
Fix propagation of read error from slurp.

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -27,7 +27,7 @@ bool slurp(const char *filename, char *destination, int size) {
         destination[n] = '\0';
     (void)close(fd);
 
-    return true;
+    return n != -1;
 }
 
 /*

--- a/src/general.c
+++ b/src/general.c
@@ -14,6 +14,9 @@
 /*
  * Reads size bytes into the destination buffer from filename.
  *
+ * On success, true is returned. Otherwise, false is returned and the content
+ * of destination is left untouched.
+ *
  */
 bool slurp(const char *filename, char *destination, int size) {
     int fd;


### PR DESCRIPTION
Hi,

I came across the `slurp()` function "succeeding" even if the underlying call to `read()` fails. When that happens the destination buffer is left uninitialized and the caller has no way to figure it out.

Although it is quite unlikely that a single call to `read()` would ever fail right after a successful call to `open(..., O_RDONLY)`, it is possible, for instance, if the file being opened is a directory.

Fixed by propagating the error (i.e. returning `false` from `slurp()`) if the call to `read()` fails.

I've also updated the documentation of the function to emphasize that the destination buffer content should not be relied upon if the `slurp()` function fails.

Hope this helps,
Olivier
