### PR TITLE
wireless: update %signal and %quality based on station info on Linux

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -189,6 +189,16 @@ static int gwi_sta_cb(struct nl_msg *msg, void *data) {
     // used to specify bit/s, so we convert to use the same code path.
     info->bitrate = (int)nla_get_u16(rinfo[NL80211_RATE_INFO_BITRATE]) * 100 * 1000;
 
+    if (sinfo[NL80211_STA_INFO_SIGNAL] != NULL) {
+        info->flags |= WIRELESS_INFO_FLAG_HAS_SIGNAL;
+        info->signal_level = (int8_t)nla_get_u8(sinfo[NL80211_STA_INFO_SIGNAL]);
+
+        info->flags |= WIRELESS_INFO_FLAG_HAS_QUALITY;
+        info->quality = nl80211_xbm_to_percent(info->signal_level, 1);
+        info->quality_max = 100;
+        info->quality_average = 50;
+    }
+
     return NL_SKIP;
 }
 


### PR DESCRIPTION
Update %signal and %quality based on beacon info instead of scan info to get updates more often.

Without this fix, values are only updated after scan requests usually triggered by tools like NetworkManager. With this fix, i3status should report different values almost every second.

Minimal config for testing:
```
order += "wireless _first_"
wireless _first_ {
	format_up = "|%signal|%quality|"
}
```
