### PR TITLE
Introduce memory options 'unit' and 'decimals'

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -431,6 +431,8 @@ int main(int argc, char *argv[]) {
         CFG_STR("threshold_degraded", NULL, CFGF_NONE),
         CFG_STR("threshold_critical", NULL, CFGF_NONE),
         CFG_STR("memory_used_method", "classical", CFGF_NONE),
+        CFG_STR("unit", "auto", CFGF_NONE),
+        CFG_INT("decimals", 1, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -763,7 +765,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC("memory") {
                 SEC_OPEN_MAP("memory");
-                print_memory(json_gen, buffer, cfg_getstr(sec, "format"), cfg_getstr(sec, "format_degraded"), cfg_getstr(sec, "threshold_degraded"), cfg_getstr(sec, "threshold_critical"), cfg_getstr(sec, "memory_used_method"));
+                print_memory(json_gen, buffer, cfg_getstr(sec, "format"), cfg_getstr(sec, "format_degraded"), cfg_getstr(sec, "threshold_degraded"), cfg_getstr(sec, "threshold_critical"), cfg_getstr(sec, "memory_used_method"), cfg_getstr(sec, "unit"), cfg_getint(sec, "decimals"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -225,7 +225,7 @@ void print_cpu_temperature_info(yajl_gen json_gen, char *buffer, int zone, const
 void print_cpu_usage(yajl_gen json_gen, char *buffer, const char *format, const char *format_above_threshold, const char *format_above_degraded_threshold, const char *path, const float max_threshold, const float degraded_threshold);
 void print_eth_info(yajl_gen json_gen, char *buffer, const char *interface, const char *format_up, const char *format_down);
 void print_load(yajl_gen json_gen, char *buffer, const char *format, const char *format_above_threshold, const float max_threshold);
-void print_memory(yajl_gen json_gen, char *buffer, const char *format, const char *format_degraded, const char *threshold_degraded, const char *threshold_critical, const char *memory_used_method);
+void print_memory(yajl_gen json_gen, char *buffer, const char *format, const char *format_degraded, const char *threshold_degraded, const char *threshold_critical, const char *memory_used_method, const char *unit, const int decimals);
 void print_volume(yajl_gen json_gen, char *buffer, const char *fmt, const char *fmt_muted, const char *device, const char *mixer, int mixer_idx);
 bool process_runs(const char *path);
 int volume_pulseaudio(uint32_t sink_idx, const char *sink_name);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -463,6 +463,15 @@ If the +format_degraded+ parameter is given and either the critical or the
 degraded threshold applies, +format_degraded+ will get used as format string.
 It acts equivalently to +format+.
 
+It's also possible to define the unit for the various format placeholders. As
++/proc/meminfo+ returns the memory in kB they will be converted to the given
+unit. If no unit is given or the +auto+ option is used, the conversion will
+select the maximum possible unit.
+
+As the converted format placeholder will be a decimal number, the number of
+decimals can be configured via the +decimals+ option. If no such option is
+given the converted format placeholder will have one decimal.
+
 As Linux' meminfo doesn't expose the overall memory in use, there are multiple
 methods to distinguish the actually used memory. 
 
@@ -475,6 +484,10 @@ methods to distinguish the actually used memory.
 *Example format*: +%free %available (%used) / %total+
 
 *Example format*: +%percentage_used used, %percentage_free free, %percentage_shared shared+
+
+*Example unit*: auto, Ki, Mi, Gi, Ti
+
+*Example decimals*: 0, 1, 2, 3
 
 *Example threshold_degraded*: +10%+
 

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -22,15 +22,19 @@ static const char memoryfile_linux[] = "/proc/meminfo";
  * Prints the given amount of bytes in a human readable manner.
  *
  */
-static int print_bytes_human(char *outwalk, uint64_t bytes) {
+static int print_bytes_human(char *outwalk, uint64_t bytes, const char *unit, const int decimals) {
     double size = bytes;
     int exponent = 0;
     int bin_base = BINARY_BASE;
     while (size >= bin_base && exponent < MAX_EXPONENT) {
+        if (strcasecmp(unit, iec_symbols[exponent]) == 0) {
+            break;
+        }
+
         size /= bin_base;
         exponent += 1;
     }
-    return sprintf(outwalk, "%.1f %sB", size, iec_symbols[exponent]);
+    return sprintf(outwalk, "%.*f %sB", decimals, size, iec_symbols[exponent]);
 }
 #endif
 
@@ -80,7 +84,7 @@ static long memory_absolute(const long mem_total, const char *size) {
 }
 #endif
 
-void print_memory(yajl_gen json_gen, char *buffer, const char *format, const char *format_degraded, const char *threshold_degraded, const char *threshold_critical, const char *memory_used_method) {
+void print_memory(yajl_gen json_gen, char *buffer, const char *format, const char *format_degraded, const char *threshold_degraded, const char *threshold_critical, const char *memory_used_method, const char *unit, const int decimals) {
     char *outwalk = buffer;
 
 #if defined(linux)
@@ -169,23 +173,23 @@ void print_memory(yajl_gen json_gen, char *buffer, const char *format, const cha
             *(outwalk++) = *walk;
 
         } else if (BEGINS_WITH(walk + 1, "total")) {
-            outwalk += print_bytes_human(outwalk, ram_total);
+            outwalk += print_bytes_human(outwalk, ram_total, unit, decimals);
             walk += strlen("total");
 
         } else if (BEGINS_WITH(walk + 1, "used")) {
-            outwalk += print_bytes_human(outwalk, ram_used);
+            outwalk += print_bytes_human(outwalk, ram_used, unit, decimals);
             walk += strlen("used");
 
         } else if (BEGINS_WITH(walk + 1, "free")) {
-            outwalk += print_bytes_human(outwalk, ram_free);
+            outwalk += print_bytes_human(outwalk, ram_free, unit, decimals);
             walk += strlen("free");
 
         } else if (BEGINS_WITH(walk + 1, "available")) {
-            outwalk += print_bytes_human(outwalk, ram_available);
+            outwalk += print_bytes_human(outwalk, ram_available, unit, decimals);
             walk += strlen("available");
 
         } else if (BEGINS_WITH(walk + 1, "shared")) {
-            outwalk += print_bytes_human(outwalk, ram_shared);
+            outwalk += print_bytes_human(outwalk, ram_shared, unit, decimals);
             walk += strlen("shared");
 
         } else if (BEGINS_WITH(walk + 1, "percentage_free")) {


### PR DESCRIPTION
Previously the format placeholders were auto-converted to the maximum possible
unit, e.g. /proc/meminfo reports MemTotal of 16307104kB which will get
converted to 15.6GiB. It is now possible to specifiy the target unit, e.g. Mi,
which will be used for the conversion - in the example it would lead to
15924.9MiB.

The resulting number can now be further formatted via the decimal option. It
allows to specify the number of decimals to use, e.g. 15.6GiB vs. 15GiB or
15924.9MiB vs. 15925MiB.