### PR TITLE
Introduce format_percentage for battery

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -369,6 +369,7 @@ int main(int argc, char *argv[]) {
     cfg_opt_t battery_opts[] = {
         CFG_STR("format", "%status %percentage %remaining", CFGF_NONE),
         CFG_STR("format_down", "No battery", CFGF_NONE),
+        CFG_STR("format_percentage", "%.02f%s", CFGF_NONE),
         CFG_STR("status_chr", "CHR", CFGF_NONE),
         CFG_STR("status_bat", "BAT", CFGF_NONE),
         CFG_STR("status_unk", "UNK", CFGF_NONE),
@@ -676,6 +677,19 @@ int main(int argc, char *argv[]) {
             cfg_general->name, cfg_general->line, interval);
     }
 
+    cfg_section = cfg_getsec(cfg, "battery");
+    if (cfg_section != NULL) {
+        bool integer_battery_capacity = cfg_getbool(cfg_section, "integer_battery_capacity");
+        char *format_percentage = cfg_getstr(cfg_section, "format_percentage");
+        if (integer_battery_capacity) {
+            if (strcmp("%.02f%s", format_percentage) == 0) {
+                cfg_setstr(cfg_section, "format_percentage", "%.00f%s");
+            } else {
+                fprintf(stderr, "i3status: integer_battery_capacity is deprecated\n");
+            }
+        }
+    }
+
     /* One memory page which each plugin can use to buffer output.
      * Even though it’s unclean, we just assume that the user will not
      * specify a format string which expands to something longer than 4096
@@ -735,7 +749,7 @@ int main(int argc, char *argv[]) {
 
             CASE_SEC_TITLE("battery") {
                 SEC_OPEN_MAP("battery");
-                print_battery_info(json_gen, buffer, (strcasecmp(title, "all") == 0 ? -1 : atoi(title)), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_unk"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getbool(sec, "integer_battery_capacity"), cfg_getbool(sec, "hide_seconds"));
+                print_battery_info(json_gen, buffer, (strcasecmp(title, "all") == 0 ? -1 : atoi(title)), cfg_getstr(sec, "path"), cfg_getstr(sec, "format"), cfg_getstr(sec, "format_down"), cfg_getstr(sec, "status_chr"), cfg_getstr(sec, "status_bat"), cfg_getstr(sec, "status_unk"), cfg_getstr(sec, "status_full"), cfg_getint(sec, "low_threshold"), cfg_getstr(sec, "threshold_type"), cfg_getbool(sec, "last_full_capacity"), cfg_getstr(sec, "format_percentage"), cfg_getbool(sec, "hide_seconds"));
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -214,7 +214,7 @@ const char *first_eth_interface(const net_type_t type);
 
 void print_ipv6_info(yajl_gen json_gen, char *buffer, const char *format_up, const char *format_down);
 void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const char *format, const char *format_below_threshold, const char *format_not_mounted, const char *prefix_type, const char *threshold_type, const double low_threshold);
-void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds);
+void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, const char *format_percentage, bool hide_seconds);
 void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *format, const char *tz, const char *locale, const char *format_time, bool hide_if_equals_localtime, time_t t);
 void print_ddate(yajl_gen json_gen, char *buffer, const char *format, time_t t);
 const char *get_ip_addr(const char *interface, int family);

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -345,8 +345,10 @@ see it this way, because it tells me how worn off my battery is.), just specify
 +last_full_capacity = true+. You can show seconds in the remaining time and
 empty time estimations by setting +hide_seconds = false+.
 
-If you want the battery percentage to be shown without decimals, add
-+integer_battery_capacity = true+.
+If you want the battery percentage to be shown in another format, use
++format_percentage+.
++integer_battery_capacity = true+ is a legacy option for
++format_percentage = "%.00f%s"+
 
 If your battery is represented in a non-standard path in /sys, be sure to
 modify the "path" property accordingly, i.e. pointing to the uevent file on
@@ -376,6 +378,8 @@ FULL) is used.
 *Example format*: +%status %remaining (%emptytime %consumption)+
 
 *Example format_down*: +No battery+
+
+*Example format_percentage*: +"%.02f%s"+
 
 *Example status_chr*: +⚡ CHR+
 

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -570,7 +570,7 @@ static bool slurp_all_batteries(struct battery_info *batt_info, yajl_gen json_ge
     return true;
 }
 
-void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, bool integer_battery_capacity, bool hide_seconds) {
+void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char *path, const char *format, const char *format_down, const char *status_chr, const char *status_bat, const char *status_unk, const char *status_full, int low_threshold, char *threshold_type, bool last_full_capacity, const char *format_percentage, bool hide_seconds) {
     const char *walk;
     char *outwalk = buffer;
     struct battery_info batt_info = {
@@ -586,7 +586,9 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__OpenBSD__)
     /* These OSes report battery stats in whole percent. */
-    integer_battery_capacity = true;
+    if (strcmp("%.02f%s", format_percentage) == 0) {
+        format_percentage = "%.00f%s";
+    }
 #endif
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__OpenBSD__)
     /* These OSes report battery time in minutes. */
@@ -687,11 +689,7 @@ void print_battery_info(yajl_gen json_gen, char *buffer, int number, const char 
             walk += strlen("status");
 
         } else if (BEGINS_WITH(walk + 1, "percentage")) {
-            if (integer_battery_capacity) {
-                outwalk += sprintf(outwalk, "%.00f%s", batt_info.percentage_remaining, pct_mark);
-            } else {
-                outwalk += sprintf(outwalk, "%.02f%s", batt_info.percentage_remaining, pct_mark);
-            }
+            outwalk += sprintf(outwalk, format_percentage, batt_info.percentage_remaining, pct_mark);
             walk += strlen("percentage");
 
         } else if (BEGINS_WITH(walk + 1, "remaining")) {


### PR DESCRIPTION
Allow custom output, backwards-compatible to `integer_battery_capacity`.

Additional info: I'm using an icon font that makes use of ligatures. I let `i3status` print something like `battery_23_charging` and the font gets a suitable glyph to display (a battery icon that is ~1/4 charged and charging).

`integer_battery_capacity` doesn't suffice, because `i3status` would still output a trailing '%' after the numeric value, which means either I get rid of the '%' or I had to adjust the font with additional ligatures.

I've also updated the documentation. The change should be backwards-compatible to `integer_battery_capacity`. If `integer_battery_capacity` is set and `format_percentage` isn't, it will be the same format as before. Setting both will override `integer_battery_capacity`.

The following screenshots show the visual difference:

![Screenshot_20191029_154430](https://user-images.githubusercontent.com/12658837/67778589-aea0f080-fa63-11e9-9e08-41d5dd6bd490.png)
![Screenshot_20191029_154756](https://user-images.githubusercontent.com/12658837/67778590-af398700-fa63-11e9-8065-8e6f7ae62f26.png)

Pushed new revision, as I got the default value wrong in the first one.