### PR TITLE
print_volume: Native NetBSD audio API support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,6 @@ case $host_os in
 	;;
 	netbsd*)
 	AC_SEARCH_LIBS([prop_string_create], [prop])
-	AC_SEARCH_LIBS([_oss_ioctl], [ossaudio])
 	;;
 esac
 


### PR DESCRIPTION
Avoid using the OSS emulation layer to fetch the master volume. Share code with OpenBSD, who inherited this API from us.

Avoid a failed read on the master control's mute enum if it can't be found, because sometimes there isn't one.