### PR TITLE
Update net-speed.sh

### DIFF
--- a/contrib/net-speed.sh
+++ b/contrib/net-speed.sh
@@ -24,7 +24,7 @@
 #
 
 # Auto detect interfaces
-ifaces=$(ls /sys/class/net | grep -E '^(eth|wlan|enp|wlp)')
+ifaces=$(ls /sys/class/net | grep -E '^(eth|wlan|enp|enx|wlp)')
 
 last_time=0
 last_rx=0


### PR DESCRIPTION
Added the common prefix `enx` as possible string for interface detection. See https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/