### PR TITLE
Allow selective pango-markup in tztime-module

### DIFF
--- a/src/print_time.c
+++ b/src/print_time.c
@@ -64,8 +64,7 @@ void print_time(yajl_gen json_gen, char *buffer, const char *title, const char *
     char string_time[STRING_SIZE];
 
     if (format_time == NULL) {
-        strftime(string_time, sizeof(string_time), format, &tm);
-        maybe_escape_markup(string_time, &outwalk);
+        outwalk += strftime(buffer, 4096, format, &tm);
     } else {
         strftime(string_time, sizeof(string_time), format_time, &tm);
         placeholder_t placeholders[] = {


### PR DESCRIPTION
This PR implements selective pango-markup in i3status (and therefore closes #421).

It makes two assumptions:
1. Results from time formatting will not introduce specifiers that will interfere with the pango-markup.
This is an assumption, but I would argue a justified one as I do not see which kind of character time formatting would (realisticly) introduce that could interfere here. One could certainly write a locale where weekday-names are in a form that this will happen, but I am not aware of any real-world locales that have such an issue.

2. The total string length will not exceed 511 characters.
This is an assumption based on the following observation:
Assume one would create a tzdata-element of the form `%Y-%m-%d %H:%M, %a`. This would be date as well as current time + the name day of the day of the week. Further assumed we would now want to give every single entry a different foreground and background color and font weight, i.e. surrounding it by a markup of type `<span background='#ffffff' foreground='#000000' weight='bold'>…</span>`. Then the resulting markup would cover 414 of 511 characters, still yielding 97 characters for the actual time strings (and possible further markup), which should therefore be a sufficiently conservative estimate.

Alternatively, instead of using a buffer size of 512, one could compute the length of the resulting string, by assuming an expansion length of qualifiers and then computing a buffer size based on the length of the actual format string, extended by this correction factor. However, this would introduce more code and be more CPU-intensive for possibly very limited gain, therefore I think the current approach seems to be preferrable.

CC @stapelberg for review, as mentioned in https://github.com/i3/i3status/issues/421

CC @sur5r

