### PR TITLE
Initialize fields with zero bytes in wireless module

### DIFF
--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -554,13 +554,13 @@ void print_wireless_info(yajl_gen json_gen, char *buffer, const char *interface,
         }
     }
 
-    char string_quality[STRING_SIZE];
-    char string_signal[STRING_SIZE];
-    char string_noise[STRING_SIZE];
-    char string_essid[STRING_SIZE];
-    char string_frequency[STRING_SIZE];
-    char string_ip[STRING_SIZE];
-    char string_bitrate[STRING_SIZE];
+    char string_quality[STRING_SIZE] = {'\0'};
+    char string_signal[STRING_SIZE] = {'\0'};
+    char string_noise[STRING_SIZE] = {'\0'};
+    char string_essid[STRING_SIZE] = {'\0'};
+    char string_frequency[STRING_SIZE] = {'\0'};
+    char string_ip[STRING_SIZE] = {'\0'};
+    char string_bitrate[STRING_SIZE] = {'\0'};
 
     if (info.flags & WIRELESS_INFO_FLAG_HAS_QUALITY) {
         if (info.quality_max)


### PR DESCRIPTION
Previously, the fields in the wireless module were declared but not explicitly
initialized upon declaration. As nothing else would do so afterwards, this
could introduce random characters left over in the memory segment into
the fields. This was explicitly observed in the essid-field, but likely
a possibility for other fields as well. Hence, this commit adds explicit
initialization with zero bytes to all fields to ensure proper
termination of all fields.

Fixes #432