### PR TITLE
print_disk_info: Use statvfs instead of statfs on OpenBSD.

### DIFF
--- a/src/print_disk_info.c
+++ b/src/print_disk_info.c
@@ -63,7 +63,7 @@ static int print_bytes_human(char *outwalk, uint64_t bytes, const char *prefix_t
  * Determines whether remaining bytes are below given threshold.
  *
  */
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__APPLE__)
 static bool below_threshold(struct statfs buf, const char *prefix_type, const char *threshold_type, const double low_threshold) {
 #else
 static bool below_threshold(struct statvfs buf, const char *prefix_type, const char *threshold_type, const double low_threshold) {
@@ -124,14 +124,14 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
 
     INSTANCE(path);
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__APPLE__)
     struct statfs buf;
 
     if (statfs(path, &buf) == -1)
         return;
 
     mounted = true;
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
     struct statvfs buf;
 
     if (statvfs(path, &buf) == -1)


### PR DESCRIPTION
This was necessary to compile on OpenBSD 6.7.

Interaction with #437 may need investigating.