### PR TITLE
Fix detection of i3status version from git when using a worktree.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AS_VAR_IF([_cv_gnu_make_command], [""], [AC_MSG_ERROR([the i3status Makefile.am 
 
 AX_EXTEND_SRCDIR
 
-AS_IF([test -d ${srcdir}/.git],
+AS_IF([test -d ${srcdir}/.git -o -f ${srcdir}/.git],
       [
         VERSION="$(git -C ${srcdir} describe --tags --abbrev=0)"
         I3STATUS_VERSION="$(git -C ${srcdir} describe --tags --always) ($(git -C ${srcdir} log --pretty=format:%cd --date=short -n1), branch \\\"$(git -C ${srcdir} describe --tags --always --all | sed s:heads/::)\\\")"


### PR DESCRIPTION
I tried to build i3status in a [worktree](https://git-scm.com/docs/git-worktree) of my clone of the git repo, and was surprised when autoconf reported the version was "not-git".  The cause is `configure.ac` checking for a `.git` _**directory**_ in the srcdir.  However, when using worktrees, `.git` is a text file that contains info about where the actual `.git` directory can be found.  The fix is, of course, to adjust the test to allow `.git` to be a file.