### PR TITLE
Fix version reporting in -h and -v.

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -510,13 +510,13 @@ int main(int argc, char *argv[]) {
                 configfile = optarg;
                 break;
             case 'h':
-                printf("i3status " VERSION " © 2008 Michael Stapelberg and contributors\n"
+                printf("i3status " I3STATUS_VERSION " © 2008 Michael Stapelberg and contributors\n"
                        "Syntax: %s [-c <configfile>] [-h] [-v]\n",
                        argv[0]);
                 return 0;
                 break;
             case 'v':
-                printf("i3status " VERSION " © 2008 Michael Stapelberg and contributors\n"
+                printf("i3status " I3STATUS_VERSION " © 2008 Michael Stapelberg and contributors\n"
 #if HAS_PULSEAUDIO
                        "Built with pulseaudio support\n"
 #else


### PR DESCRIPTION
Since the conversion to autotools, `i3status -h` and `i3status -v` no longer report the "full" i3status version.  Instead of reporting a string like `2.13-100-gf119d9b (2021-02-08, branch "testing")`, it simply reports `2.13`.  This means that a patched or custom compiled version is indistinguishable from an actual release binary, which is obviously bad for diagnostics.

The cause is that in the old `Makefile`, `-DVERSION` was set to the contents of `${I3STATUS_VERSION}`, whereas autotools sets the value of `VERSION` directly in `config.h` (to `${VERSION}`, not `${I3STATUS_VERSION}`).

Rather than try to change the `VERSION` macro back to the old format (which might break things that make assumptions about autotools' format of `VERSION`), I just updated the `i3status -h` and `i3status -v` code to directly use `I3STATUS_VERSION` instead of `VERSION`.