### PR TITLE
battery: set status to full when battery is not charging

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -185,9 +185,9 @@ static bool slurp_battery_info(battery_info_ctx_t *ctx, struct battery_info *bat
             batt_info->present_rate = abs(atoi(walk + 1));
         else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Charging"))
             batt_info->status = CS_CHARGING;
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Full"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Full") || BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Not charging"))
             batt_info->status = CS_FULL;
-        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Discharging") || BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Not charging"))
+        else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS=Discharging"))
             batt_info->status = CS_DISCHARGING;
         else if (BEGINS_WITH(last, "POWER_SUPPLY_STATUS="))
             batt_info->status = CS_UNKNOWN;

--- a/testcases/023-battery-not-charging/expected_output.txt
+++ b/testcases/023-battery-not-charging/expected_output.txt
@@ -1,1 +1,1 @@
-BAT
+FULL


### PR DESCRIPTION
As reported in this [comment](https://github.com/i3/i3status/issues/304#issuecomment-962655488), when the reported battery status is:

    POWER_SUPPLY_STATUS=Not charging

The battery is actually full, therefore not charging anymore. Currently i3status shows the battery as discharging.