### PR TITLE
Allow to build inside of a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ If you absolutely have to build from source, use:
   ninja
   sudo ninja install
 ```
+
+If you like to build inside of a Docker container, see [these instructions](./docker).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bullseye
+
+VOLUME /src
+
+WORKDIR /src
+
+ADD ./i3status_build /usr/local/bin
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        autoconf \
+        libconfuse-dev \
+        libyajl-dev \
+        libasound2-dev \
+        libiw-dev \
+        asciidoc \
+        libpulse-dev \
+        libnl-genl-3-dev \
+        meson \
+        gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT /usr/local/bin/i3status_build

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,16 @@
+# Build with Docker
+
+If you prefer to build i3status inside of a Docker container, from the main directory of this repo, do the following:
+
+1. build the image using the Dockerfile in the `docker` directory:
+   ```
+   sudo docker build -t i3status-meson-builder ./docker
+   ```
+2. start the build:
+   ```
+   sudo docker run -it -v `pwd`:/src i3status-meson-builder
+   ```
+3. find your `i3status` binary in the `./build/` directory, move it to `/usr/bin`
+   ```
+   sudo mv ./build/i3status /usr/bin/i3status
+   ```

--- a/docker/i3status_build
+++ b/docker/i3status_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p /src/build &&
+pushd /src/build &&
+meson .. &&
+ninja
+
+exit $?


### PR DESCRIPTION
In order to be able to build the project inside of a Docker container, I added a new subdirectory in the root, `docker` with a Dockerfile and instructions about how to build.