### PR TITLE
time: fix to use format_time

### DIFF
--- a/src/print_time.c
+++ b/src/print_time.c
@@ -71,7 +71,7 @@ void print_time(time_ctx_t *ctx) {
             {.name = "%time", .value = string_time}};
 
         const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
-        char *formatted = format_placeholders(ctx->format_time, &placeholders[0], num);
+        char *formatted = format_placeholders(ctx->format, &placeholders[0], num);
         OUTPUT_FORMATTED;
         free(formatted);
     }


### PR DESCRIPTION
## Problem

It seems that `format_time` of `tztime` doesn't works correctly after v2.14.

If the configuration as written as below, the string expected to be printed is `"<span foreground='#ee9a00'>21-11-14 (Sun) 02:27:51</span>"` but I got `"%y-%m-%d (%a) %H:%M:%S"`.

```
tztime local {
  format = "<span foreground='#ee9a00'>time:</span> %time"
  format_time = "%H:%M %Z"
}
```

The detailed behavior of `format_time` is described in the doc: https://i3wm.org/docs/i3status.html#_time

## Cause

The cause of this is `format` is not correctly.
`format` should be used when printing but `format_time` is used in v2.14.

The source code of the previous version v2.13 uses `format`.
https://github.com/i3/i3status/blame/101215bbc83b97de30b6b535bbe2e93d2e913804/src/print_time.c#L68-L77

This pull request fixes it.