### PR TITLE
Allow nicely displaying uptime.

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -342,6 +342,13 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_SEPARATOR_OPT,
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
         CFG_END()};
+        
+    cfg_opt_t uptime_opts[] = {
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_CUSTOM_SEPARATOR_OPT,
+        CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
+        CFG_END()};
 
     cfg_opt_t tztime_opts[] = {
         CFG_STR("format", "%Y-%m-%d %H:%M:%S %Z", CFGF_NONE),
@@ -467,6 +474,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("volume", volume_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ipv6", ipv6_opts, CFGF_NONE),
         CFG_SEC("time", time_opts, CFGF_NONE),
+        CFG_SEC("uptime", uptime_opts, CFGF_NONE),
         CFG_SEC("tztime", tztime_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ddate", ddate_opts, CFGF_NONE),
         CFG_SEC("load", load_opts, CFGF_NONE),
@@ -847,6 +855,17 @@ int main(int argc, char *argv[]) {
                     .t = tv.tv_sec,
                 };
                 print_time(&ctx);
+                SEC_CLOSE_MAP;
+            }
+            
+            CASE_SEC("uptime") {
+                SEC_OPEN_MAP("uptime");
+                uptime_ctx_t ctx = {
+                    .json_gen = json_gen,
+                    .buf = buffer,
+                    .buflen = sizeof(buffer),
+                };
+                print_uptime(&ctx);
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -86,7 +86,7 @@ extern char *pct_mark;
     do {                                                                                             \
         /* Terminate the output buffer here in any case, so that it’s                              \
          * not forgotten in the module */                                                            \
-        /**outwalk = '\0';*/                                                                             \
+        outwalk = '\0';                                                                             \
         if (output_format == O_I3BAR) {                                                              \
             char *_markup = cfg_getstr(cfg_general, "markup");                                       \
             yajl_gen_string(ctx->json_gen, (const unsigned char *)"markup", strlen("markup"));       \

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -86,7 +86,7 @@ extern char *pct_mark;
     do {                                                                                             \
         /* Terminate the output buffer here in any case, so that it’s                              \
          * not forgotten in the module */                                                            \
-        *outwalk = '\0';                                                                             \
+        /**outwalk = '\0';*/                                                                             \
         if (output_format == O_I3BAR) {                                                              \
             char *_markup = cfg_getstr(cfg_general, "markup");                                       \
             yajl_gen_string(ctx->json_gen, (const unsigned char *)"markup", strlen("markup"));       \
@@ -439,7 +439,13 @@ typedef struct {
     const int max_chars;
 } file_contents_ctx_t;
 
-void print_file_contents(file_contents_ctx_t *ctx);
+typedef struct {
+    yajl_gen json_gen;
+    char *buf;
+    const size_t buflen;
+} uptime_ctx_t;
+
+void print_uptime(uptime_ctx_t *ctx);
 
 /* socket file descriptor for general purposes */
 extern int general_socket;

--- a/src/print_uptime.c
+++ b/src/print_uptime.c
@@ -1,0 +1,56 @@
+// vim:ts=4:sw=4:expandtab
+#include <config.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <locale.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_version.h>
+
+#include "i3status.h"
+
+static const char uptimefile_linux[] = "/proc/uptime";
+
+void print_uptime(uptime_ctx_t *ctx) {
+#if defined(__linux__)
+     char *outwalk = ctx->buf;
+     
+     FILE *file = fopen(uptimefile_linux, "r");
+
+     // bailout if open failed
+     if (!file) {
+          OUTPUT_FULL_TEXT("can't read uptime");
+          fputs("i3status: Cannot read system uptime using /proc/uptime\n", stderr);
+          return;
+     }
+     
+     char uptime_buffer[256]; //should be good...
+     
+     fgets(uptime_buffer, sizeof uptime_buffer, file);
+     
+     //the first field of /proc/uptime is the uptime in seconds
+     long int uptime = strtol(uptime_buffer, NULL, 10);
+     
+     // stolen from coreutils' uptime.c 
+     long int updays = uptime / 86400;
+     long int uphours = (uptime - (updays * 86400)) / 3600;
+     long int upmins = (uptime - (updays * 86400) - (uphours * 3600)) / 60;
+     
+     if (0 < updays) {
+          outwalk += sprintf(outwalk, "UP: %ld days, %ld:%ld",updays,uphours,upmins);
+          *outwalk = '\0';
+     } else {
+          outwalk += sprintf(outwalk, "UP: %ld:%ld",uphours,upmins);
+     }
+     
+     *outwalk = '\0';
+     
+     OUTPUT_FULL_TEXT(ctx->buf);
+     
+     return;
+#else
+    OUTPUT_FULL_TEXT("");
+    fputs("i3status: Uptime status information is not supported on this system\n", stderr);
+#endif
+}

--- a/src/print_uptime.c
+++ b/src/print_uptime.c
@@ -48,7 +48,7 @@ void print_uptime(uptime_ctx_t *ctx) {
      
      OUTPUT_FULL_TEXT(ctx->buf);
      
-     return;
+     fclose(file);
 #else
     OUTPUT_FULL_TEXT("");
     fputs("i3status: Uptime status information is not supported on this system\n", stderr);


### PR DESCRIPTION
Adds ``uptime`` module that displays the uptime in this format ``UP: 10 days, 23:1``.

This is not possible with ``read_file``