### PR TITLE
Custom battery `%emptytime` string when battery is full

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -328,6 +328,7 @@ int main(int argc, char *argv[]) {
         CFG_BOOL("last_full_capacity", false, CFGF_NONE),
         CFG_BOOL("integer_battery_capacity", false, CFGF_NONE),
         CFG_BOOL("hide_seconds", true, CFGF_NONE),
+        CFG_STR("battery_full_emptytime", "", CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -747,6 +748,7 @@ int main(int argc, char *argv[]) {
                     .last_full_capacity = cfg_getbool(sec, "last_full_capacity"),
                     .format_percentage = cfg_getstr(sec, "format_percentage"),
                     .hide_seconds = cfg_getbool(sec, "hide_seconds"),
+                    .battery_full_emptytime = cfg_getstr(sec, "battery_full_emptytime"),
                 };
                 print_battery_info(&ctx);
                 SEC_CLOSE_MAP;

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -276,6 +276,7 @@ typedef struct {
     bool last_full_capacity;
     const char *format_percentage;
     bool hide_seconds;
+    const char *battery_full_emptytime;
 } battery_info_ctx_t;
 
 void print_battery_info(battery_info_ctx_t *ctx);

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -702,6 +702,9 @@ void print_battery_info(battery_info_ctx_t *ctx) {
             snprintf(string_emptytime, STRING_SIZE, "%02d:%02d:%02d", max(empty_tm->tm_hour, 0), max(empty_tm->tm_min, 0), max(empty_tm->tm_sec, 0));
     }
 
+    if (batt_info.seconds_remaining < 0 && ctx->battery_full_emptytime[0] != 0)
+        snprintf(string_emptytime, STRING_SIZE, "%s", ctx->battery_full_emptytime);
+
     if (batt_info.present_rate >= 0)
         snprintf(string_consumption, STRING_SIZE, "%1.2fW", batt_info.present_rate / 1e6);
 


### PR DESCRIPTION
Allow a custom string return for `%emptytime` for when battery is full. The custom string can be set from the config file in `battery` module with the option `battery_full_emptytime`.

Current behavior of `%emptytime` when battery is full is as below.

![image](https://user-images.githubusercontent.com/46749569/149643619-fca8391c-1512-42b8-9042-a2372069829e.png)
```
battery all {
        format = "<span background='#458588'> %percentage %status (while != %emptytime) </span>"
        low_threshold = 30
        threshold_type = "percentage"
}
```

Instead, battery module will display such as below with this PR.

![image](https://user-images.githubusercontent.com/46749569/149644488-bf173530-7d51-42b0-a515-9d2ceff1009a.png)
```
battery all {
        format = "<span background='#458588'> %percentage %status (while != %emptytime) </span>"
        low_threshold = 30
        threshold_type = "percentage"
        battery_full_emptytime = "false"
}
```
