### PR TITLE
Add new module to allow screen-brightness

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -280,6 +280,17 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t brightness_opts[] = {
+        CFG_STR("format", "Brightness: %brightness%", CFGF_NONE),
+        CFG_STR("brightness_path", "/sys/class/backlight/intel_backlight/brightness", CFGF_NONE),
+        CFG_STR("max_brightness_path", "/sys/class/backlight/intel_backlight/max_brightness", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_CUSTOM_SEPARATOR_OPT,
+        CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
+        CFG_END()};
+
     cfg_opt_t wireless_opts[] = {
         CFG_STR("format_up", "W: (%quality at %essid, %bitrate) %ip", CFGF_NONE),
         CFG_STR("format_down", "W: down", CFGF_NONE),
@@ -459,6 +470,7 @@ int main(int argc, char *argv[]) {
         CFG_SEC("general", general_opts, CFGF_NONE),
         CFG_SEC("run_watch", run_watch_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("path_exists", path_exists_opts, CFGF_TITLE | CFGF_MULTI),
+        CFG_SEC("brightness", brightness_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("wireless", wireless_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("ethernet", ethernet_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("battery", battery_opts, CFGF_TITLE | CFGF_MULTI),
@@ -779,6 +791,21 @@ int main(int argc, char *argv[]) {
                     .format_down = cfg_getstr(sec, "format_down"),
                 };
                 print_path_exists(&ctx);
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC_TITLE("brightness") {
+                SEC_OPEN_MAP("brightness");
+                brightness_ctx_t ctx = {
+                    .json_gen = json_gen,
+                    .buf = buffer,
+                    .buflen = sizeof(buffer),
+                    .title = title,
+                    .format = cfg_getstr(sec, "format"),
+                    .brightness_path = cfg_getstr(sec, "brightness_path"),
+                    .max_brightness_path = cfg_getstr(sec, "max_brightness_path"),
+                };
+                print_brightness(&ctx);
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -339,6 +339,18 @@ typedef struct {
     char *buf;
     const size_t buflen;
     const char *title;
+    const char *format;
+    const char *brightness_path;
+    const char *max_brightness_path;
+} brightness_ctx_t;
+
+void print_brightness(brightness_ctx_t *ctx);
+
+typedef struct {
+    yajl_gen json_gen;
+    char *buf;
+    const size_t buflen;
+    const char *title;
     const char *path;
     const char *format;
     const char *format_down;

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ i3status_srcs = [
   'src/print_mem.c',
   'src/print_path_exists.c',
   'src/print_run_watch.c',
+  'src/print_brightness.c',
   'src/print_time.c',
   'src/print_volume.c',
   'src/print_wireless_info.c',

--- a/src/print_brightness.c
+++ b/src/print_brightness.c
@@ -1,0 +1,45 @@
+// vim:ts=4:sw=4:expandtab
+#include <stdlib.h>
+#include "i3status.h"
+
+#define STRING_SIZE 5
+
+static int get_brightness(const char *brt, const char *max_brt) {
+  FILE *brt_file = fopen(brt, "r");
+  if (!brt_file)
+    return -1;
+  FILE *max_brt_file = fopen(max_brt, "r");
+  if (!max_brt_file) {
+    fclose(brt_file);
+    return -2;
+  }
+
+  char value[20];
+  char max_value[20];
+
+  fgets(value, 20, brt_file);
+  fgets(max_value, 20, max_brt_file);
+  fclose(brt_file);
+  fclose(max_brt_file);
+
+  unsigned long actual = strtod(value, NULL);
+  unsigned long max = strtod(max_value, NULL);
+
+  return actual * 100 / max;
+}
+
+void print_brightness(brightness_ctx_t *ctx) {
+  int brightness = get_brightness(ctx->brightness_path, ctx->max_brightness_path);
+  const char *walk = ctx->format;
+  char *outwalk = ctx->buf;
+
+  char string_brightness[STRING_SIZE];
+  snprintf(string_brightness, STRING_SIZE, "%d", brightness);
+  placeholder_t placeholders[] = {
+    {.name = "%brightness", .value = string_brightness }};
+
+  const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
+  char *formatted = format_placeholders(walk, &placeholders[0], num);
+  OUTPUT_FORMATTED;
+  OUTPUT_FULL_TEXT(ctx->buf);
+}


### PR DESCRIPTION
New module 'brightness' takes two file enpoints (like in
/sys/class/backlight) that return a numeric value, then displays this as
'brightness'.