### PR TITLE
Port memory printing on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On debian-based systems, the following line will install all requirements:
 apt-get install autoconf libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libpulse-dev libnl-genl-3-dev meson
 ```
 
-On OpenBSD, the following line will install some of the requirements:
+On OpenBSD, the following line will install the requirements:
 ```bash
 pkg_add autoconf libconfuse libyajl asciidoc pluseaudio meson
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ On debian-based systems, the following line will install all requirements:
 apt-get install autoconf libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libpulse-dev libnl-genl-3-dev meson
 ```
 
+On OpenBSD, the following line will install all requirements:
+```bash
+pkg_add pluseaudio meson
+```
+
 ## Upstream
 
 i3status is developed at https://github.com/i3/i3status

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ On debian-based systems, the following line will install all requirements:
 apt-get install autoconf libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libpulse-dev libnl-genl-3-dev meson
 ```
 
-On OpenBSD, the following line will install all requirements:
+On OpenBSD, the following line will install some of the requirements:
 ```bash
-pkg_add pluseaudio meson
+pkg_add autoconf libconfuse libyajl asciidoc pluseaudio meson
 ```
 
 ## Upstream

--- a/src/print_cpu_usage.c
+++ b/src/print_cpu_usage.c
@@ -45,14 +45,12 @@ struct cpu_usage {
     long system;
     long idle;
     long total;
+    int spin;
 #else
     int user;
     int nice;
     int system;
     int idle;
-#if defined(__OpenBSD__)
-    int spin;
-#endif
     int total;
 #endif
 };

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -40,8 +40,8 @@ static int print_percentage(char *outwalk, float percent) {
     return snprintf(outwalk, STRING_SIZE, "%.1f%s", percent, pct_mark);
 }
 
-static unsigned long page2mbyte (unsigned pageCnt) {
-    return (pageCnt * getpagesize ()) >> 20;
+static unsigned long page2byte (unsigned pageCnt) {
+    return pageCnt * getpagesize ();
 }
 
 #if defined(__linux__)
@@ -181,9 +181,9 @@ error:
         return;
     }
 
-    minfo->ram_total = page2mbyte(our_uvmexp.npages);
-    minfo->ram_free  = page2mbyte(our_uvmexp.free + our_uvmexp.inactive);
-    minfo->ram_used  = page2mbyte(our_uvmexp.npages - our_uvmexp.free - our_uvmexp.inactive);
+    minfo->ram_total = page2byte(our_uvmexp.npages);
+    minfo->ram_free  = page2byte(our_uvmexp.free + our_uvmexp.inactive);
+    minfo->ram_used  = page2byte(our_uvmexp.npages - our_uvmexp.free - our_uvmexp.inactive);
     minfo->ram_available = minfo->ram_free;
     minfo->ram_buffers = 0;
     minfo->ram_cached = 0;

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -194,7 +194,7 @@ error:
 #endif
 }
 
-void print_formatted_memory(struct print_mem_info *minfo, memory_ctx_t *ctx) {
+static void print_formatted_memory(struct print_mem_info *minfo, memory_ctx_t *ctx) {
     char *outwalk = ctx->buf;
     const char *selected_format = ctx->format;
     char string_ram_total[STRING_SIZE];

--- a/src/print_mem.c
+++ b/src/print_mem.c
@@ -144,7 +144,6 @@ static void get_memory_info(struct print_mem_info *minfo, memory_ctx_t *ctx) {
     minfo->ram_cached *= 1024UL;
     minfo->ram_shared *= 1024UL;
 
-    unsigned long minfo->ram_used;
     if (BEGINS_WITH(ctx->memory_used_method, "memavailable")) {
         minfo->ram_used = minfo->ram_total - minfo->ram_available;
     } else if (BEGINS_WITH(ctx->memory_used_method, "classical")) {


### PR DESCRIPTION
- Split print_memory into get_memory_info which is platform dependent and print_formatted_memory which is platform independent
- Created struct print_mem_info that keeps memory counters which will be passed between get_memory_info and print_formatted_memory
- Used UVM subsystem to get memory counters on OpenBSD
- Added the requirements in README
- src/print_cpu_usage.c does not compile on OpenBSD because of the conditional definition of \_\_OpenBSD\_\_