### PR TITLE
cpu_temperature: support format_down

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -406,6 +406,7 @@ int main(int argc, char *argv[]) {
     cfg_opt_t temp_opts[] = {
         CFG_STR("format", "%degrees C", CFGF_NONE),
         CFG_STR("format_above_threshold", NULL, CFGF_NONE),
+        CFG_STR("format_down", "can't read temp", CFGF_NONE),
         CFG_STR("path", NULL, CFGF_NONE),
         CFG_INT("max_threshold", 75, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
@@ -907,6 +908,7 @@ int main(int argc, char *argv[]) {
                     .path = cfg_getstr(sec, "path"),
                     .format = cfg_getstr(sec, "format"),
                     .format_above_threshold = cfg_getstr(sec, "format_above_threshold"),
+                    .format_down = cfg_getstr(sec, "format_down"),
                     .max_threshold = cfg_getint(sec, "max_threshold"),
                 };
                 print_cpu_temperature_info(&ctx);

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -354,6 +354,7 @@ typedef struct {
     const char *path;
     const char *format;
     const char *format_above_threshold;
+    const char *format_down;
     int max_threshold;
 } cpu_temperature_ctx_t;
 

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -421,7 +421,8 @@ Gets the temperature of the given thermal zone. It is possible to
 define a +max_threshold+ that will color the temperature red in case the
 specified thermal zone is getting too hot. Defaults to 75 degrees C. The
 output format when above +max_threshold+ can be customized with
-+format_above_threshold+.
++format_above_threshold+. There also is an option +format_down+. You can hide
+the output with +format_down=""+.
 
 *Example order*: +cpu_temperature 0+
 

--- a/src/print_cpu_temperature.c
+++ b/src/print_cpu_temperature.c
@@ -272,6 +272,6 @@ error:
     free(thermal_zone);
 #endif
 
-    OUTPUT_FULL_TEXT("can't read temp");
+    OUTPUT_FULL_TEXT(ctx->format_down);
     (void)fputs("i3status: Cannot read temperature. Verify that you have a thermal zone in /sys/class/thermal or disable the cpu_temperature module in your i3status config.\n", stderr);
 }


### PR DESCRIPTION
With this, users are able to create portable config by, for example, two
cpu_temperature for coretemp and k10temp with format_down="".