### PR TITLE
Revert "Use the PulseAudio port name rather than the sink name (#419)"

### DIFF
--- a/src/pulse.c
+++ b/src/pulse.c
@@ -122,14 +122,13 @@ static void store_info_from_sink_cb(pa_context *c,
     int avg_vol = pa_cvolume_avg(&info->volume);
     int vol_perc = roundf((float)avg_vol * 100 / PA_VOLUME_NORM);
     int composed_volume = COMPOSE_VOLUME_MUTE(vol_perc, info->mute);
-    const char *desc = (info->active_port != NULL) ? info->active_port->description : info->description;
 
     /* if this is the default sink we must try to save it twice: once with
      * DEFAULT_SINK_INDEX as the index, and another with its proper value
      * (using bitwise OR to avoid early-out logic) */
     if ((info->index == default_sink_idx &&
-         save_info(DEFAULT_SINK_INDEX, composed_volume, desc, NULL)) |
-        save_info(info->index, composed_volume, desc, info->name)) {
+         save_info(DEFAULT_SINK_INDEX, composed_volume, info->description, NULL)) |
+        save_info(info->index, composed_volume, info->description, info->name)) {
         /* if the volume, mute flag or description changed, wake the main thread */
         pthread_kill(main_thread, SIGUSR1);
     }


### PR DESCRIPTION
Changing the port name is not as straighforward as changing the device description.
Changing the device description is easy and supported in multiple modern media backends such as pipewire-media-session and Wireplumber.

Also, the device description is unique most of the time in default deployments. The port name is often the same across different devices such as "Digital Output (S/PDIF)" or "Speakers". This leads to confusion when changing the output device via hotkeys and checking the active device via i3status in uncustomized i3status configurations.

Furthermore, in pavucontrol, when assigning output/input devices, the port name does not show up, only the device description does. The port name is not used very often around interfacing with the audio backend as opposed to the device description, which is typically used in various places around third-party apps.

This reverts commit 09358d26982431702c3652e8f07ebff7166a1181.