### PR TITLE
Display CPU usage as a bar graph using Unicode characters

### DIFF
--- a/man/i3status.man
+++ b/man/i3status.man
@@ -453,9 +453,13 @@ when above degraded threshold can be customized with
 For displaying the Nth CPU usage, you can use the %cpu<N> format string,
 starting from %cpu0. This feature is currently not supported in FreeBSD.
 
+CPU usage can also be represented graphically using %usagebar and %cpubar<N>
+instead of, respectively, %usage and %cpu<N>. This feature requires the use
+of a (preferrably, monospace) font implementing "Block Elements" 
+
 *Example order*: +cpu_usage+
 
-*Example format*: +all: %usage CPU_0: %cpu0 CPU_1: %cpu1+
+*Example format*: +all: %usage [%cpubar0%cpubar1]+
 
 *Example max_threshold*: +75+
 


### PR DESCRIPTION
Extends configuration keywords "%usage" with "%usagebar" and "%cpu<n>" with "%cpubar<n>", which display the corresponding statistics as a bar, one character wide, instead of a percentage. These keywords can be combined within a single configuration.

The graph is relatively coarse, with a resolution of 11 percentage points per bar increment, but it compresses the width of the representation from (typically) four characters to one. This is particularly useful on machines with larger numbers of cores.