### PR TITLE
Correctly format tztime

### DIFF
--- a/src/print_time.c
+++ b/src/print_time.c
@@ -71,7 +71,7 @@ void print_time(time_ctx_t *ctx) {
             {.name = "%time", .value = string_time}};
 
         const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
-        char *formatted = format_placeholders(ctx->format_time, &placeholders[0], num);
+        char *formatted = format_placeholders(ctx->format, &placeholders[0], num);
         OUTPUT_FORMATTED;
         free(formatted);
     }


### PR DESCRIPTION
The format uses an incorrect source string to replate %time placeholder with the corresponding datetime value, as a result we output a format string instead of formatted value