### PR TITLE
add an option to colour battery indicator when full

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -328,6 +328,7 @@ int main(int argc, char *argv[]) {
         CFG_BOOL("last_full_capacity", false, CFGF_NONE),
         CFG_BOOL("integer_battery_capacity", false, CFGF_NONE),
         CFG_BOOL("hide_seconds", true, CFGF_NONE),
+        CFG_BOOL("full_good", false, CFGF_NONE),
         CFG_CUSTOM_ALIGN_OPT,
         CFG_CUSTOM_COLOR_OPTS,
         CFG_CUSTOM_MIN_WIDTH_OPT,
@@ -747,6 +748,7 @@ int main(int argc, char *argv[]) {
                     .last_full_capacity = cfg_getbool(sec, "last_full_capacity"),
                     .format_percentage = cfg_getstr(sec, "format_percentage"),
                     .hide_seconds = cfg_getbool(sec, "hide_seconds"),
+                    .full_good = cfg_getbool(sec, "full_good"),
                 };
                 print_battery_info(&ctx);
                 SEC_CLOSE_MAP;

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -276,6 +276,7 @@ typedef struct {
     bool last_full_capacity;
     const char *format_percentage;
     bool hide_seconds;
+    bool full_good;
 } battery_info_ctx_t;
 
 void print_battery_info(battery_info_ctx_t *ctx);

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -646,6 +646,10 @@ void print_battery_info(battery_info_ctx_t *ctx) {
             batt_info.seconds_remaining = 0;
     }
 
+    if (batt_info.status == CS_FULL && ctx->full_good ){
+        START_COLOR("color_good");
+        colorful_output = true;
+    }
     if (batt_info.status == CS_DISCHARGING && ctx->low_threshold > 0) {
         if (batt_info.percentage_remaining >= 0 && strcasecmp(ctx->threshold_type, "percentage") == 0 && batt_info.percentage_remaining < ctx->low_threshold) {
             START_COLOR("color_bad");


### PR DESCRIPTION
hi. I guess `color_good` should be used when the battery is full,  as that is somehow an "optimal" condition. my pr adds that functionality, by providing a `full_good` boolean switch that defaults to false (just to be cautious). 
I haven't studied the code very deeply, but at least it worked when i tried it. hope this isn't buggy.  cheers.
