### PR TITLE
feat: add netspeed as a C module

### DIFF
--- a/i3status.c
+++ b/i3status.c
@@ -455,9 +455,20 @@ int main(int argc, char *argv[]) {
         CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
         CFG_END()};
 
+    cfg_opt_t netspeed_opts[] = {
+        CFG_STR("format", "Down: %down/s Up: %up/s", CFGF_NONE),
+        CFG_CUSTOM_ALIGN_OPT,
+        CFG_CUSTOM_COLOR_OPTS,
+        CFG_CUSTOM_MIN_WIDTH_OPT,
+        CFG_CUSTOM_SEPARATOR_OPT,
+        CFG_CUSTOM_SEP_BLOCK_WIDTH_OPT,
+        CFG_END()};
+
+
     cfg_opt_t opts[] = {
         CFG_STR_LIST("order", "{}", CFGF_NONE),
         CFG_SEC("general", general_opts, CFGF_NONE),
+        CFG_SEC("netspeed", netspeed_opts, CFGF_NONE),
         CFG_SEC("run_watch", run_watch_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("path_exists", path_exists_opts, CFGF_TITLE | CFGF_MULTI),
         CFG_SEC("wireless", wireless_opts, CFGF_TITLE | CFGF_MULTI),
@@ -726,6 +737,18 @@ int main(int argc, char *argv[]) {
                     .format_down = cfg_getstr(sec, "format_down"),
                 };
                 print_eth_info(&ctx);
+                SEC_CLOSE_MAP;
+            }
+
+            CASE_SEC("netspeed") {
+                SEC_OPEN_MAP("netspeed");
+                netspeed_ctx_t ctx = {
+                    .json_gen = json_gen,
+                    .buf = buffer,
+                    .buflen = sizeof(buffer),
+                    .format = cfg_getstr(sec, "format"),
+                };
+                print_netspeed(&ctx);
                 SEC_CLOSE_MAP;
             }
 

--- a/include/i3status.h
+++ b/include/i3status.h
@@ -327,6 +327,15 @@ typedef struct {
     yajl_gen json_gen;
     char *buf;
     const size_t buflen;
+    const char *format;
+} netspeed_ctx_t;
+
+void print_netspeed(netspeed_ctx_t *ctx);
+
+typedef struct {
+    yajl_gen json_gen;
+    char *buf;
+    const size_t buflen;
     const char *title;
     const char *pidfile;
     const char *format;

--- a/man/i3status.man
+++ b/man/i3status.man
@@ -353,6 +353,14 @@ network interface found on the system (excluding devices starting with "lo").
 
 *Example format_down*: +E: down+
 
+=== Netspeed
+
+Shows the traffic per seconnd for all physical network interfaces.
+
+*Example order*: +netspeed+
+
+*Example format*: +%down/s↓ %up/s↑+
+
 === Battery
 
 Gets the status (charging, discharging, unknown, full), percentage, remaining

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ i3status_srcs = [
   'src/print_mem.c',
   'src/print_path_exists.c',
   'src/print_run_watch.c',
+  'src/print_netspeed.c',
   'src/print_time.c',
   'src/print_volume.c',
   'src/print_wireless_info.c',

--- a/src/print_netspeed.c
+++ b/src/print_netspeed.c
@@ -1,0 +1,108 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+
+#include "i3status.h"
+
+#define NET_STAT_BUFFER_SIZE 100
+#define RATE_BUFFER_SIZE 10
+
+
+typedef struct {
+    unsigned long last_time;
+    unsigned long last_rx;
+    unsigned long last_tx;
+    char last_rate_down[RATE_BUFFER_SIZE];
+    char last_rate_up[RATE_BUFFER_SIZE];
+} NetworkState;
+
+static NetworkState prev_state = {
+    0,
+    0,
+    0,
+    {'0', '\0'},
+    {'0', '\0'}
+};
+
+void readable(unsigned long bytes, char *output) {
+    unsigned long kb = bytes / 1000;  // Convert to kilobytes (base-10)
+    if (kb < 1000) {
+        sprintf(output, "%lu KB", kb);
+    } else {
+        unsigned long mb_int = kb / 1000;
+        unsigned long mb_dec = (kb % 1000 * 100) / 1000; // Multiplied by 100, then divided by 1000 for 2 decimal places
+        sprintf(output, "%lu.%02lu MB", mb_int, mb_dec);
+    }
+}
+
+void print_netspeed(netspeed_ctx_t *ctx) {
+    char *outwalk = ctx->buf;
+    const char *selected_format = ctx->format;
+
+    unsigned long current_time = (unsigned long) time(NULL);  // Renamed variable
+
+    DIR *d;
+    d = opendir("/sys/class/net");
+    if (d ==NULL) return;
+
+    int ret;
+    char path[PATH_MAX], line[PATH_MAX];
+    char interface[PATH_MAX];
+    char resolved_path[PATH_MAX];
+    struct dirent *dir;
+    unsigned long rx = 0, tx = 0;
+
+    while ((dir = readdir(d)) != NULL) {
+        if (strcmp(dir->d_name, ".") == 0 || strcmp(dir->d_name, "..") == 0) continue;
+
+        snprintf(interface, sizeof(interface), "/sys/class/net/%s", dir->d_name);
+
+        if (realpath(interface, resolved_path) == NULL) continue;
+        if (strstr(resolved_path, "devices/virtual") != NULL) continue; // only get for physical devices
+
+        ret = snprintf(path, sizeof(path), "/sys/class/net/%s/statistics/rx_bytes", dir->d_name);
+        if (ret >= sizeof(path) || ret < 0) continue;
+
+        FILE *fp = fopen(path, "r");
+        fgets(line, NET_STAT_BUFFER_SIZE, fp);
+        fclose(fp);
+        rx += strtoul(line, NULL, 10);
+
+        ret = snprintf(path, sizeof(path), "/sys/class/net/%s/statistics/tx_bytes", dir->d_name);
+        if (ret >= sizeof(path) || ret < 0) continue;
+
+        fp = fopen(path, "r");
+        fgets(line, NET_STAT_BUFFER_SIZE, fp);
+        fclose(fp);
+        tx += strtoul(line, NULL, 10);
+    }
+    closedir(d);
+
+    unsigned long interval = current_time - prev_state.last_time;
+    if (interval > 0) {
+        char rate_down[RATE_BUFFER_SIZE], rate_up[RATE_BUFFER_SIZE];
+
+        readable((rx - prev_state.last_rx) / interval, rate_down);
+        readable((tx - prev_state.last_tx) / interval, rate_up);
+
+        strncpy(prev_state.last_rate_down, rate_down, RATE_BUFFER_SIZE);
+        strncpy(prev_state.last_rate_up, rate_up, RATE_BUFFER_SIZE);
+
+        prev_state.last_time = current_time;
+        prev_state.last_rx = rx;
+        prev_state.last_tx = tx;
+    }
+
+    placeholder_t placeholders[] = {
+        {.name = "%down", .value = prev_state.last_rate_down },
+        {.name = "%up", .value = prev_state.last_rate_up }
+    };
+
+    const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
+    char *formatted = format_placeholders(selected_format, &placeholders[0], num);
+    OUTPUT_FORMATTED;
+    free(formatted);
+    OUTPUT_FULL_TEXT(ctx->buf);
+}
+


### PR DESCRIPTION
this commit adds the functionality from the bash script as a C module. Currently it supports no options for choice of interfaces, as it just aggregates the network traffic across all physical interfaces, which is what what most users want.