### PR TITLE
[496 Battery module incorrectly trims whitespace]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ On debian-based systems, the following line will install all requirements:
 apt-get install autoconf libconfuse-dev libyajl-dev libasound2-dev libiw-dev asciidoc libpulse-dev libnl-genl-3-dev meson
 ```
 
+On arch-based systems, the following line will install all requirements:
+```bash
+pacman -S base-devel alsa-lib confuse libnl libpulse yajl meson asciidoc
+```
+
 ## Upstream
 
 i3status is developed at https://github.com/i3/i3status

--- a/src/output.c
+++ b/src/output.c
@@ -122,36 +122,3 @@ void maybe_escape_markup(char *text, char **buffer) {
         }
     }
 }
-
-/*
- * remove leading spaces
- */
-char *ltrim(const char *s) {
-    while (isspace(*s))
-        ++s;
-    return sstrdup(s);
-}
-
-/*
- * remove trailing spaces
- */
-char *rtrim(const char *s) {
-    char *r = sstrdup(s);
-    if (r != NULL) {
-        char *fr = r + strlen(s) - 1;
-        while ((isspace(*fr) || *fr == 0) && fr >= r)
-            --fr;
-        *++fr = 0;
-    }
-    return r;
-}
-
-/*
- * remove leading & trailing spaces
- */
-char *trim(const char *s) {
-    char *r = rtrim(s);
-    char *f = ltrim(r);
-    free(r);
-    return f;
-}

--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -285,10 +285,10 @@ static bool slurp_battery_info(battery_info_ctx_t *ctx, struct battery_info *bat
         batt_info->status = CS_DISCHARGING;
 #elif defined(__OpenBSD__)
     /*
-	 * We're using apm(4) here, which is the interface to acpi(4) on amd64/i386 and
-	 * the generic interface on macppc/sparc64/zaurus.  Machines that have ACPI
-	 * battery sensors gain some extra information.
-	 */
+     * We're using apm(4) here, which is the interface to acpi(4) on amd64/i386 and
+     * the generic interface on macppc/sparc64/zaurus.  Machines that have ACPI
+     * battery sensors gain some extra information.
+     */
     struct apm_power_info apm_info;
     struct sensordev sensordev;
     struct sensor sensor;
@@ -726,11 +726,9 @@ void print_battery_info(battery_info_ctx_t *ctx) {
         {.name = "%consumption", .value = string_consumption}};
 
     const size_t num = sizeof(placeholders) / sizeof(placeholder_t);
-    char *untrimmed = format_placeholders(ctx->format, &placeholders[0], num);
-    char *formatted = trim(untrimmed);
+    char *formatted = format_placeholders(ctx->format, &placeholders[0], num);
     OUTPUT_FORMATTED;
     free(formatted);
-    free(untrimmed);
 
     if (colorful_output) {
         END_COLOR;

--- a/src/print_eth_info.c
+++ b/src/print_eth_info.c
@@ -106,9 +106,9 @@ static int print_eth_speed(char *outwalk, const char *interface) {
 
     for (desc = ifm_subtype_descriptions; desc->ifmt_string != NULL; desc++) {
         /*
-		 * Skip these non-informative values and go right ahead to the
-		 * actual speeds.
-		 */
+         * Skip these non-informative values and go right ahead to the
+         * actual speeds.
+         */
         if (BEGINS_WITH(desc->ifmt_string, "autoselect") ||
             BEGINS_WITH(desc->ifmt_string, "auto"))
             continue;
@@ -157,7 +157,7 @@ void print_eth_info(eth_info_ctx_t *ctx) {
     /*
      * Removing '%' and following characters from IPv6 since the interface identifier is redundant,
      * as the output already includes the interface name.
-    */
+     */
     if (ipv6_address != NULL) {
         char *prct_ptr = strstr(ipv6_address, "%");
         if (prct_ptr != NULL) {

--- a/src/print_wireless_info.c
+++ b/src/print_wireless_info.c
@@ -402,9 +402,9 @@ error1:
     close(s);
     if (na.i_len >= sizeof(u.req)) {
         /*
-	 * Just use the first BSSID returned even if there are
-	 * multiple APs sharing the same BSSID.
-	 */
+         * Just use the first BSSID returned even if there are
+         * multiple APs sharing the same BSSID.
+         */
         info->signal_level = u.req.info[0].isi_rssi / 2 +
                              u.req.info[0].isi_noise;
         info->flags |= WIRELESS_INFO_FLAG_HAS_SIGNAL;
@@ -523,7 +523,7 @@ void print_wireless_info(wireless_info_ctx_t *ctx) {
     /*
      * Removing '%' and following characters from IPv6 since the interface identifier is redundant,
      * as the output already includes the interface name.
-    */
+     */
     if (ipv6_address != NULL) {
         char *prct_ptr = strstr(ipv6_address, "%");
         if (prct_ptr != NULL) {

--- a/testcases/014-battery-capacity/expected_output.txt
+++ b/testcases/014-battery-capacity/expected_output.txt
@@ -1,1 +1,1 @@
-Touchpad: 100.00% BAT
+Touchpad: 100.00% BAT 


### PR DESCRIPTION
+ Added dependencies for arch-based systems in the README.md;
- Removed the trim functions in the output.c, it was only used by print_battery_info (dead code);
- Removed the forced trimming in print_battery_info; = Modifed the expected output of the 014 test. There is an space between
  the two last %parameters, the expected output must reflect this space
  character;
= print_eth_info and print_wireless_info got modifed by running
  clang-format -i **/*.[ch] (clang-format version 16.0.3) as specified
  in the CONTRIBUTING.md file;

Note:
  I believe the initial intent of the trimming was to remove spaces due
  to empty values such as in this example: %remaining having no value
  when the battery is at 100%.

  It creates a tailing space, which was in the formatting, made by the user,
  to separate the last two parameters.

  format: ... %status %remaining
  result: ... [status value][space][empty string here due to no value]

  Although, even with the trimming, an empty value right in the middle of
  a set of %parameters will still make empty spaces.

  I tested the claim other modules not trimning and it was the true. In
  other words, the trimming did not fix anything and it was causing this
  module to behave abnormally.