### PR TITLE
battery: Increase strings maximum size

### DIFF
--- a/src/print_battery_info.c
+++ b/src/print_battery_info.c
@@ -10,7 +10,7 @@
 
 #include "i3status.h"
 
-#define STRING_SIZE 10
+#define STRING_SIZE 128
 
 #if defined(__linux__)
 #include <errno.h>


### PR DESCRIPTION
Allows e.g. putting pango markup inside status strings.

Fixes #516