### PR TITLE
maybe_escape_markup: Don't mangle output if markup is disabled

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -92,7 +92,7 @@ void maybe_escape_markup(char *text, char *buffer, size_t size) {
     size--; /* Leave a byte for NUL termination. */
 
     if (markup_format == M_NONE) {
-        *buffer += snprintf(buffer, size, "%s", text);
+        snprintf(buffer, size, "%s", text);
         return;
     }
 


### PR DESCRIPTION
As it is, the code modifies the first char of `buffer`, increasing it by the number of bytes written.