### PR TITLE
Update meson setup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you absolutely have to build from source, use:
 ```bash
   mkdir build
   cd build
-  meson ..
+  meson setup
   ninja
   sudo ninja install
 ```


### PR DESCRIPTION
This is a very easy fix, when I run the README instructions `meson ..`, I get the following warning:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
The fix is to just run `meson setup` instead and it works like a charm.